### PR TITLE
(#25) Swagger API Docs 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 application.yml
+fir-d1e55-firebase-adminsdk-tm2jt-6ef434d608.json
 
 ### STS ###
 .apt_generated

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,10 +25,16 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	runtimeOnly 'mysql:mysql-connector-java'	
-	implementation group: 'com.google.firebase', name: 'firebase-admin', version: '8.1.0'	
-	implementation 'org.springframework.boot:spring-boot-starter-security:2.5.5'	
-	implementation group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.1.1'	
+	runtimeOnly 'mysql:mysql-connector-java'
+	implementation group: 'com.google.firebase', name: 'firebase-admin', version: '8.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-security:2.5.5'
+	implementation group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.1.1'
+	runtimeOnly 'mysql:mysql-connector-java'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-ui:1.5.2'
+	compileOnly("javax.annotation:javax.annotation-api:1.2")
+
 }
 
 test {

--- a/backend/src/main/java/com/aespa/nextplace/config/SecurityConfig.java
+++ b/backend/src/main/java/com/aespa/nextplace/config/SecurityConfig.java
@@ -1,22 +1,26 @@
 package com.aespa.nextplace.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import com.aespa.nextplace.util.FirebaseTokenFilter;
+import com.google.firebase.auth.FirebaseAuth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
-import com.aespa.nextplace.util.FirebaseTokenFilter;
-import com.google.firebase.auth.FirebaseAuth;
-
-import lombok.RequiredArgsConstructor;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -28,9 +32,37 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final FirebaseAuth firebaseAuth;
 
     @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        DaoAuthenticationProvider daoAuthenticationProvider = new DaoAuthenticationProvider();
+        daoAuthenticationProvider.setPasswordEncoder(new BCryptPasswordEncoder());
+        daoAuthenticationProvider.setUserDetailsService(this.userDetailsService);
+
+        auth.authenticationProvider(daoAuthenticationProvider);
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Override
     public void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
                 .anyRequest().authenticated().and()
+                .httpBasic().disable()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .cors().configurationSource(corsConfigurationSource())
+                .and()
                 .addFilterBefore(new FirebaseTokenFilter(userDetailsService, firebaseAuth),
                      UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling()
@@ -40,7 +72,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     public void configure(WebSecurity web) throws Exception {
         // 회원가입, 메인페이지, 리소스
-    		web.ignoring().antMatchers("/user/**")
+    		web.ignoring().antMatchers("/user/**", "/api-docs","/swagger", "/swagger-ui/**")
 //				web.ignoring().antMatchers(HttpMethod.POST, "/user/**")
             .antMatchers("/")
             .antMatchers("/resources/**");

--- a/backend/src/main/java/com/aespa/nextplace/config/SwaggerConfiguration.java
+++ b/backend/src/main/java/com/aespa/nextplace/config/SwaggerConfiguration.java
@@ -1,0 +1,51 @@
+package com.aespa.nextplace.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfiguration {
+    public static final String SECURITY_SCHEMA_NAME = "bearer";
+    public static final String AUTHORIZATION_SCOPE_GLOBAL = "global";
+    public static final String AUTHORIZATION_SCOPE_GLOBAL_DESC = "accessEverything";
+
+    private Info info() {
+        return new Info().title("Next Place")
+                .description("<h2>Next Place API Reference Document for AESPA</h2>")
+                .termsOfService("https://github.com/483759/Next-Place")
+                .contact(new Contact().name("김경원, 박근일, 윤이진, 이상현, 이종은").email("483759@naver.com"))
+                .license(new License().name("Apache License Version 2.0").url("http://www.apache.org/licenses/LICENSE-2.0"))
+                .version("1.0");
+    }
+
+    @Bean
+    public OpenAPI openAPI(@Value("${springdoc.version}") String appVersion) {
+        Info info = new Info().title("Next Place")
+                .description("<h2>Next Place API Reference Document for AESPA</h2>")
+                .termsOfService("https://edu.ssafy.com")
+                .contact(new Contact().name("김경원, 박근일, 윤이진, 이상현, 이종은").email("483759@naver.com"))
+                .license(new License().name("Apache License Version 2.0").url("http://www.apache.org/licenses/LICENSE-2.0"))
+                .version("1.0");
+
+        SecurityScheme basicAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization");
+        SecurityRequirement securityItem = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", basicAuth))
+                .addSecurityItem(securityItem)
+                .info(info)
+                ;
+
+    }
+
+}

--- a/backend/src/main/java/com/aespa/nextplace/config/WebConfiguration.java
+++ b/backend/src/main/java/com/aespa/nextplace/config/WebConfiguration.java
@@ -1,0 +1,14 @@
+package com.aespa.nextplace.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfiguration implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") //모든 요청에 대해서
+                .allowedOrigins("http://localhost", "https://localhost"); //허용할 오리진들
+    }
+}

--- a/backend/src/main/java/com/aespa/nextplace/controller/PlamonController.java
+++ b/backend/src/main/java/com/aespa/nextplace/controller/PlamonController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlamonController {
     private final PlamonService plamonService;
 
-    @GetMapping("/all/{oauthUid}")
+    @GetMapping("/{oauthUid}")
     public ResponseEntity<ListPlamonResponse> readAllPlamon(@PathVariable String oauthUid) {
         ListPlamonResponse list = plamonService.findAllByUser(oauthUid);
 


### PR DESCRIPTION
## Motivation

- API 요청 및 응답 명세를 확인할 수 있고 API 테스트를 할 수 있는 기능 필요

<br>

## Key Changes

![image](https://user-images.githubusercontent.com/30489264/140016637-8de52753-3318-425c-a3a9-2038b7754390.png)


- Swagger 3을 적용해서 Bearer 기반 토큰 인증 방식을 사용할 수 있게 했습니다
- Security에 Swagger 관련 Request Path를 추가했습니다