### PR TITLE
Close (#30) 전체 Pladex(고유 플레몬) 리스트 조회

### DIFF
--- a/backend/src/main/java/com/aespa/nextplace/controller/PladexController.java
+++ b/backend/src/main/java/com/aespa/nextplace/controller/PladexController.java
@@ -1,0 +1,28 @@
+package com.aespa.nextplace.controller;
+
+import com.aespa.nextplace.model.response.ListPladexResponse;
+import com.aespa.nextplace.service.PladexService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/pladex")
+@RequiredArgsConstructor
+public class PladexController {
+    private final PladexService pladexService;
+
+    @GetMapping("")
+    @Operation(summary = "전체 Pladex 반환", description = "전체 Pledex 리스트(고유 Plamon)을 반환한다", responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    public ResponseEntity<ListPladexResponse> readAll() {
+        ListPladexResponse pladexList = pladexService.findAll();
+
+        return ResponseEntity.ok(pladexList);
+    }
+}

--- a/backend/src/main/java/com/aespa/nextplace/model/repository/PladexRepository.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/repository/PladexRepository.java
@@ -1,0 +1,9 @@
+package com.aespa.nextplace.model.repository;
+
+import com.aespa.nextplace.model.entity.Pladex;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PladexRepository extends JpaRepository<Pladex, Long> {
+}

--- a/backend/src/main/java/com/aespa/nextplace/model/response/ListPladexResponse.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/response/ListPladexResponse.java
@@ -1,0 +1,19 @@
+package com.aespa.nextplace.model.response;
+
+import com.aespa.nextplace.model.entity.Pladex;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ListPladexResponse {
+    private List<PladexResponse> pladexList;
+
+    public ListPladexResponse(List<Pladex> pladexList) {
+        this.pladexList = new ArrayList<>();
+        for(var pladex: pladexList) {
+            this.pladexList.add(new PladexResponse(pladex));
+        }
+    }
+}

--- a/backend/src/main/java/com/aespa/nextplace/model/response/PladexResponse.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/response/PladexResponse.java
@@ -2,13 +2,21 @@ package com.aespa.nextplace.model.response;
 
 import com.aespa.nextplace.model.entity.Pladex;
 import com.aespa.nextplace.model.entity.PlamonRank;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class PladexResponse {
+    @Schema(example = "217592")
     private Long id;
+
+    @Schema(example = "실험몬")
     private String name;
+
+    @Schema(example = "어느 대학원생이 랩실에 혼자 남아 실험을 하다가 몬스터가 되었다는 소문이 있다")
     private String information;
+
+    @Schema(example = "R")
     private PlamonRank rank;
 
     public PladexResponse(Pladex pladex) {

--- a/backend/src/main/java/com/aespa/nextplace/service/PladexService.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PladexService.java
@@ -1,0 +1,7 @@
+package com.aespa.nextplace.service;
+
+import com.aespa.nextplace.model.response.ListPladexResponse;
+
+public interface PladexService {
+    ListPladexResponse findAll();
+}

--- a/backend/src/main/java/com/aespa/nextplace/service/PladexServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PladexServiceImpl.java
@@ -1,0 +1,21 @@
+package com.aespa.nextplace.service;
+
+import com.aespa.nextplace.model.repository.PladexRepository;
+import com.aespa.nextplace.model.response.ListPladexResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PladexServiceImpl implements PladexService{
+
+    private final PladexRepository pladexRepo;
+
+    @Override
+    public ListPladexResponse findAll() {
+        return new ListPladexResponse(pladexRepo.findAll());
+    }
+
+}

--- a/backend/src/test/java/com/aespa/nextplace/plamon/PladexServiceTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/plamon/PladexServiceTest.java
@@ -1,0 +1,69 @@
+package com.aespa.nextplace.plamon;
+
+import com.aespa.nextplace.model.entity.Pladex;
+import com.aespa.nextplace.model.entity.PlamonRank;
+import com.aespa.nextplace.model.repository.PladexRepository;
+import com.aespa.nextplace.service.PladexServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+public class PladexServiceTest {
+
+    @InjectMocks
+    PladexServiceImpl pladexService;
+
+    @Mock
+    PladexRepository pladexRepo;
+
+    private Pladex createPladexOfId(long id) {
+        return Pladex.builder()
+                .id(id)
+                .name("test")
+                .information("test info")
+                .rank(PlamonRank.SR)
+                .build();
+    }
+
+    @DisplayName("모든 플레덱스(고유 플레몬)의 리스트를 반환한다")
+    @Test
+    public void 플레덱스리스트반환() throws Exception {
+        //given
+        List<Pladex> pladexes = List.of(
+                createPladexOfId(1L),
+                createPladexOfId(2L),
+                createPladexOfId(3L)
+        );
+
+        given(pladexRepo.findAll())
+                .willReturn(pladexes);
+
+        //when
+        var pladexResponseDto = pladexService.findAll().getPladexList();
+
+        //then
+        assertThat(pladexResponseDto.size())
+                .isEqualTo(3);
+        assertThat(pladexResponseDto)
+                .extracting("id", "name")
+                .containsExactly(
+                        tuple(1L, "test"),
+                        tuple(2L, "test"),
+                        tuple(3L, "test")
+                );
+        verify(pladexRepo).findAll();
+    }
+}

--- a/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
@@ -21,7 +21,7 @@ import static org.mockito.BDDMockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @Transactional
-class ReadPlamonList {
+class PlamonServiceTest {
 
     @InjectMocks
     PlamonServiceImpl plamonService;


### PR DESCRIPTION
## Motivation

- 유저가 가진 플레몬이 아닌 고유한 플레몬 리스트를 조회하기 위한 기능 필요

<br>

## Key Changes

- Pladex에 대한 Repository, Service, Controller, Test 클래스를 생성했습니다
- Swagger를 통한 API 문서를 자세히 표시하기 위해 다음과 같은 사항을 추가했습니다
  - 기존 Pladex의 DTO 필드에 `@Schema`를 추가
  - Controller에 API Response 종류 명시

<br>

## To Reviewers

- 플레몬을 추가할 수 있는 API를 구현하고, 이후에 관리자 유저에게만 접근 권한을 부여하고 싶은데 우선순위는 미루겠습니당
