### PR TITLE
Close #55 - PlamonServiceTest 오류 수정

### DIFF
--- a/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
@@ -9,7 +9,6 @@ import com.aespa.nextplace.service.PlamonServiceImpl;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -27,7 +26,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Transactional
 class PlamonServiceTest {
 


### PR DESCRIPTION
## Motivation 🤔

![image](https://user-images.githubusercontent.com/30489264/140861693-08a59d13-15aa-4c8e-a969-b9f21e577d00.png)

- PlamonServiceTest를 테스트할 때 각각의 테스트 메서드를 따로 실행하면 성공하는데, 한번에 실행하면 실패하는 현상 발생

<br>

## Key Changes 🔑

![image](https://user-images.githubusercontent.com/30489264/140861742-4b547567-8ccf-47ce-bfe0-b7cb3313b816.png)

- 기존 `@BeforeAll` 어노테이션을 써보기 위해 추가해줬던 `@TestInstance(TestInstance.Lifecycle.PER_CLASS)`가 원인
  - 해당 방식은 테스트 클래스 당 인스턴스를 하나만 생성하기 때문에 테스트의 독립적인 수행이 보장받을 수 없었음

<br>

## To Reviewers 🙏

- 하나의 어노테이션을 달더라도 꼭 잘 알아보고 달아야 한다는 것을 깨달았습니다
