### PR TITLE
Close #52 - security config 수정

### DIFF
--- a/backend/src/main/java/com/aespa/nextplace/config/SecurityConfig.java
+++ b/backend/src/main/java/com/aespa/nextplace/config/SecurityConfig.java
@@ -74,6 +74,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         // 회원가입, 메인페이지, 리소스
         web.ignoring().antMatchers("/user/**", "/swagger/**", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**")
 //				web.ignoring().antMatchers(HttpMethod.POST, "/user/**")
+                .antMatchers("/**")
                 .antMatchers("/")
                 .antMatchers("/resources/**");
     }


### PR DESCRIPTION
## Motivation 🤔

- 현재 인증 기능을 사용하기 위한 수단은 유니티 -> 구글 Oauth -> 서버의 흐름이 강제됨

<br>

## Key Changes 🔑

- 비즈니스 로직을 우선 구현하고, 마지막에 인증을 적용하기 위해 서버의 SecurityConfig에서 모든 URI를 허용하도록 했습니다