### PR TITLE
Close #77 - Feature/read all plamon

### DIFF
--- a/backend/src/main/java/com/aespa/nextplace/controller/PlamonController.java
+++ b/backend/src/main/java/com/aespa/nextplace/controller/PlamonController.java
@@ -1,7 +1,7 @@
 package com.aespa.nextplace.controller;
 
 import com.aespa.nextplace.model.response.ErrorResponse;
-import com.aespa.nextplace.model.response.ListPlamonResponse;
+import com.aespa.nextplace.model.response.ListAllPlamonResponse;
 import com.aespa.nextplace.model.response.PlamonResponse;
 import com.aespa.nextplace.service.PlamonService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,13 +18,14 @@ import org.springframework.web.bind.annotation.*;
 public class PlamonController {
     private final PlamonService plamonService;
 
-    @GetMapping("/all/{oauthUid}")
+    @GetMapping("")
     @Operation(summary = "내 캐릭터 조회", description = "유저가 소유한 캐릭터 목록을 조회한다", responses = {
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
-    public ResponseEntity<?> readAllPlamon(@PathVariable String oauthUid) {
+    public ResponseEntity<?> readAllPlamon() {
+        String oauthUid = "G-12345";
         try {
-            ListPlamonResponse list = plamonService.findAllByUser(oauthUid);
+            ListAllPlamonResponse list = plamonService.findAllByUser(oauthUid);
 
             return ResponseEntity.ok(list);
         } catch (IllegalArgumentException e) {      // 유저 정보 없음

--- a/backend/src/main/java/com/aespa/nextplace/model/response/ListAllPlamonResponse.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/response/ListAllPlamonResponse.java
@@ -1,0 +1,25 @@
+package com.aespa.nextplace.model.response;
+
+import com.aespa.nextplace.model.entity.Pladex;
+import com.aespa.nextplace.model.entity.Plamon;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ListAllPlamonResponse {
+    @Schema(description = "보유한 캐릭터")
+    List<PlamonResponse> myPlamon;
+    @Schema(description = "보유하지 않은 캐릭터")
+    ListPladexResponse notMyPlamon;
+
+    public ListAllPlamonResponse(List<Plamon> myPlamon, List<Pladex> notMyPlamon) {
+        this.myPlamon = new ArrayList<>();
+        for(var plamon: myPlamon) {
+            this.myPlamon.add(new PlamonResponse(plamon));
+        }
+        this.notMyPlamon = new ListPladexResponse(notMyPlamon);
+    }
+}

--- a/backend/src/main/java/com/aespa/nextplace/model/response/ListPlamonResponse.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/response/ListPlamonResponse.java
@@ -1,6 +1,7 @@
 package com.aespa.nextplace.model.response;
 
 import com.aespa.nextplace.model.entity.Plamon;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.util.ArrayList;
@@ -8,15 +9,12 @@ import java.util.List;
 
 @Getter
 public class ListPlamonResponse {
+    @Schema(description = "플레몬 리스트")
     private List<PlamonResponse> plamonList = new ArrayList<>();
 
-    public ListPlamonResponse(List<Plamon> plamonList, boolean ownFlag) {
-        concatList(plamonList, ownFlag);
-    }
-
-    public void concatList(List<Plamon> plamonList, boolean ownFlag) {
+    public ListPlamonResponse(List<Plamon> plamonList) {
         for(var plamon: plamonList) {
-            this.plamonList.add(new PlamonResponse(plamon, ownFlag));
+            this.plamonList.add(new PlamonResponse(plamon));
         }
     }
 }

--- a/backend/src/main/java/com/aespa/nextplace/model/response/PlamonResponse.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/response/PlamonResponse.java
@@ -1,25 +1,34 @@
 package com.aespa.nextplace.model.response;
 
 import com.aespa.nextplace.model.entity.Plamon;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class PlamonResponse {
+    @Schema(example = "1")
     private Long id;
+
+    @Schema(example = "1")
     private int level;
+
+    @Schema(example = "10")
     private int exp;
+
+    @Schema(example = "실험몬")
     private String nickname;
+
+    @Schema(example = "true")
     private boolean isMain;
-    private boolean ownFlag;
+
     private PladexResponse pladex;
 
-    public PlamonResponse(Plamon plamon, boolean ownFlag) {
+    public PlamonResponse(Plamon plamon) {
         this.id = plamon.getId();
         this.level = plamon.getLevel();
         this.exp = plamon.getExp();
         this.nickname = plamon.getNickname();
         this.isMain = plamon.isMain();
-        this.ownFlag = ownFlag;
         this.pladex = new PladexResponse(plamon.getPladex());
     }
 }

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonService.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonService.java
@@ -1,9 +1,9 @@
 package com.aespa.nextplace.service;
 
-import com.aespa.nextplace.model.response.ListPlamonResponse;
+import com.aespa.nextplace.model.response.ListAllPlamonResponse;
 import com.aespa.nextplace.model.response.PlamonResponse;
 
 public interface PlamonService {
-    ListPlamonResponse findAllByUser(String oauthUid);
+    ListAllPlamonResponse findAllByUser(String oauthUid);
     PlamonResponse buyNewPlamonWithGold(String oauthUid);
 }

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
@@ -7,7 +7,7 @@ import com.aespa.nextplace.model.entity.User;
 import com.aespa.nextplace.model.repository.PladexRepository;
 import com.aespa.nextplace.model.repository.PlamonRepository;
 import com.aespa.nextplace.model.repository.UserRepository;
-import com.aespa.nextplace.model.response.ListPlamonResponse;
+import com.aespa.nextplace.model.response.ListAllPlamonResponse;
 import com.aespa.nextplace.model.response.PlamonResponse;
 import com.aespa.nextplace.util.PlamonRankUtil;
 import org.springframework.stereotype.Service;
@@ -38,7 +38,7 @@ public class PlamonServiceImpl implements PlamonService {
     }
 
     @Override
-    public ListPlamonResponse findAllByUser(String oauthUid) {
+    public ListAllPlamonResponse findAllByUser(String oauthUid) {
         User user = findUserByOauthUid(oauthUid);
 
         if (user == null) {
@@ -46,17 +46,9 @@ public class PlamonServiceImpl implements PlamonService {
         }
 
         List<Plamon> plamonList = plamonRepo.findAllByUser(user);
-        ListPlamonResponse response = new ListPlamonResponse(plamonList, true);
+        List<Pladex> notMyPlamonList = pladexRepo.findAllByUserWithNotMine(user);
 
-        List<Plamon> notMinePlamonList = new ArrayList<>();
-
-        for(var plamon: pladexRepo.findAllByUserWithNotMine(user)) {
-            notMinePlamonList.add(new Plamon(plamon, user));
-        }
-
-        response.concatList(notMinePlamonList, false);
-
-        return response;
+        return new ListAllPlamonResponse(plamonList, notMyPlamonList);
     }
 
     public PlamonRank getPlamonRank() {
@@ -142,6 +134,6 @@ public class PlamonServiceImpl implements PlamonService {
         Plamon plamon = plamonRepo.save(new Plamon(randomPlamon, user));
         user.minusGold(rankUtil.getGatchaPrice());
 
-        return new PlamonResponse(plamon, true);
+        return new PlamonResponse(plamon);
     }
 }


### PR DESCRIPTION
## Motivation 🤔

- 경원님이 구현하신 Response 방식과 같이 보유 여부에 따라 리스트를 분할해서 반환하도록 수정

<br>

## Key Changes 🔑

- myPlamon, notMyPlamon으로 구분해서 캐릭터 리스트를 조회한다
- 가지고 있는 캐릭터는 중복을 허용한다
- 가지고 있지 않은 캐릭터는 기본 정보만으로 구성되어 있다
- 각각의 캐릭터 리스트를 배열로 담아서 반환한다

<details>
<summary>응답 예시</summary>

```json
{
  "myPlamon": [
    {
      "id": 1,
      "level": 1,
      "exp": 10,
      "nickname": "랩실노예",
      "pladex": {
        "id": 1,
        "name": "실험몬",
        "information": "어느 대학원생이 랩실에 혼자 남아 실험을 하다가 몬스터가 되었다는 소문이 있다",
        "rank": "R"
      },
      "main": false
    },
    {
      "id": 2,
      "level": 1,
      "exp": 0,
      "nickname": "윤이진",
      "pladex": {
        "id": 2,
        "name": "윤이진",
        "information": "대전 궁동에서 주로 아침8시, 새벽 1시에 출몰한다",
        "rank": "SR"
      },
      "main": false
    },
    {
      "id": 3,
      "level": 1,
      "exp": 0,
      "nickname": "윤이진",
      "pladex": {
        "id": 2,
        "name": "윤이진",
        "information": "대전 궁동에서 주로 아침8시, 새벽 1시에 출몰한다",
        "rank": "SR"
      },
      "main": false
    },
    {
      "id": 4,
      "level": 1,
      "exp": 0,
      "nickname": "실험몬",
      "pladex": {
        "id": 1,
        "name": "실험몬",
        "information": "어느 대학원생이 랩실에 혼자 남아 실험을 하다가 몬스터가 되었다는 소문이 있다",
        "rank": "R"
      },
      "main": false
    },
    {
      "id": 5,
      "level": 1,
      "exp": 0,
      "nickname": "실험몬",
      "pladex": {
        "id": 1,
        "name": "실험몬",
        "information": "어느 대학원생이 랩실에 혼자 남아 실험을 하다가 몬스터가 되었다는 소문이 있다",
        "rank": "R"
      },
      "main": false
    },
    {
      "id": 7,
      "level": 1,
      "exp": 0,
      "nickname": "성심당빵 시바",
      "pladex": {
        "id": 6,
        "name": "성심당빵 시바",
        "information": "성심당 개맛있다 시바~!",
        "rank": "R"
      },
      "main": true
    },
    {
      "id": 8,
      "level": 1,
      "exp": 0,
      "nickname": "오리인 척하는 오리너구리",
      "pladex": {
        "id": 14,
        "name": "오리인 척하는 오리너구리",
        "information": "오리연못 짱이 나야 -!",
        "rank": "R"
      },
      "main": false
    }
  ],
  "notMyPlamon": {
    "pladexList": [
      {
        "id": 3,
        "name": "싸탈자",
        "information": "어제까지는 팀원이었던 사람이 오늘 보이지 않는다면 싸탈자일 가능성이 크다",
        "rank": "N"
      },
      {
        "id": 8,
        "name": "계룡산 꽃분",
        "information": "신선님을 뵈러 오셨다구요 ?",
        "rank": "SR"
      },
      {
        "id": 9,
        "name": "식장산 선녀",
        "information": "식장산은 야경이 유명하지… 밤에 다시오시오.",
        "rank": "SSR"
      },
      {
        "id": 10,
        "name": "꿈돌이",
        "information": "ㄱ나니...? 나는 너를 다시 만나는게 꿈이였어...!",
        "rank": "N"
      },
      {
        "id": 11,
        "name": "드루이드",
        "information": "내가 한밭수목원을 수호하겠다 -!",
        "rank": "SR"
      },
      {
        "id": 12,
        "name": "유림공원 유생",
        "information": "유성의 유자는 유학의 유",
        "rank": "N"
      },
      {
        "id": 13,
        "name": "목척교 미래인",
        "information": "이곳은 목척교고 지금은 2035년이야.",
        "rank": "SR"
      },
      {
        "id": 15,
        "name": "온천 고양이들",
        "information": "흐으... 역시 온천은 유성온천이지....",
        "rank": "N"
      }
    ]
  }
}
```

</details>
