### PR TITLE
Close #84 - 달고나를 사용해서 캐릭터 레벨 업

### DIFF
--- a/backend/src/main/java/com/aespa/nextplace/controller/PlamonController.java
+++ b/backend/src/main/java/com/aespa/nextplace/controller/PlamonController.java
@@ -1,11 +1,13 @@
 package com.aespa.nextplace.controller;
 
+import com.aespa.nextplace.model.request.PlamonLevelUpRequest;
 import com.aespa.nextplace.model.response.ErrorResponse;
 import com.aespa.nextplace.model.response.ListAllPlamonResponse;
 import com.aespa.nextplace.model.response.ListSellPlamonResponse;
 import com.aespa.nextplace.model.response.PlamonResponse;
 import com.aespa.nextplace.service.PlamonService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.parser.ParseException;
@@ -81,5 +83,27 @@ public class PlamonController {
                     .body(new ErrorResponse(e.getMessage()));
         }
 
+    }
+
+    @PostMapping("/levelup")
+    @Operation(summary = "캐릭터 레벨 업", description = "달고나를 사용해서 캐릭터를 레벨 업 시킨다", responses = {
+            @ApiResponse(responseCode = "200", description = "구매 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못 된 요청"),
+            @ApiResponse(responseCode = "401", description = "유저 정보 없음")
+    })
+    public ResponseEntity<?> levelUpPlamonByDalgona(@RequestBody @Parameter(description = "레벨 업에 필요한 정보", required = true) PlamonLevelUpRequest request) throws ParseException {
+        String oauthUid = "G-12345";
+
+        try {
+            PlamonResponse response = plamonService.levelUpWithDalgona(oauthUid, request);
+
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {      // 유저 정보 없음
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ErrorResponse(e.getMessage()));
+        } catch (IllegalStateException e) {         // 달고나 부족 or 존재하지 않는 캐릭터
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ErrorResponse(e.getMessage()));
+        }
     }
 }

--- a/backend/src/main/java/com/aespa/nextplace/model/entity/Experience.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/entity/Experience.java
@@ -1,0 +1,23 @@
+package com.aespa.nextplace.model.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Experience {
+    @Id @Column(name = "exp_level")
+    int level;
+    @Column(name = "exp_accumulated")
+    int accumulated;
+    @Column(name = "exp_next")
+    int next;
+}

--- a/backend/src/main/java/com/aespa/nextplace/model/entity/Experience.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/entity/Experience.java
@@ -14,10 +14,11 @@ import javax.persistence.Id;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Experience {
-    @Id @Column(name = "exp_level")
-    int level;
+    @Id
+    @Column(name = "exp_level")
+    private int level;
     @Column(name = "exp_accumulated")
-    int accumulated;
+    private int accumulated;
     @Column(name = "exp_next")
-    int next;
+    private int next;
 }

--- a/backend/src/main/java/com/aespa/nextplace/model/entity/Plamon.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/entity/Plamon.java
@@ -60,4 +60,14 @@ public class Plamon {
         this.pladex = pladex;
         this.user = user;
     }
+
+    /**
+     * @param newExp 새로운 누적 경험치
+     * @param next 다음 레벨에 대한 정보
+     * @implNote 레벨과 경험치를 갱신한다
+     * */
+    public void levelUp(int newExp, Experience next) {
+        this.level = next.getLevel();
+        this.exp = newExp - next.getAccumulated();
+    }
 }

--- a/backend/src/main/java/com/aespa/nextplace/model/entity/Plamon.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/entity/Plamon.java
@@ -1,5 +1,6 @@
 package com.aespa.nextplace.model.entity;
 
+import com.aespa.nextplace.util.LevelUtil;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -69,8 +70,10 @@ public class Plamon {
     public void levelUp(int newExp, Experience next) {
         this.level = next.getLevel();
         this.exp = newExp - next.getAccumulated();
-        if (this.level == 15 && this.exp > 1490) {
-            this.exp = 1490;
+
+        LevelUtil levelUtil = LevelUtil.getInstance();
+        if (this.level == levelUtil.getMAXLEVEL() && this.exp > levelUtil.getMAXEXP()) {
+            this.exp = levelUtil.getMAXEXP();
         }
     }
 }

--- a/backend/src/main/java/com/aespa/nextplace/model/entity/Plamon.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/entity/Plamon.java
@@ -69,5 +69,8 @@ public class Plamon {
     public void levelUp(int newExp, Experience next) {
         this.level = next.getLevel();
         this.exp = newExp - next.getAccumulated();
+        if (this.level == 15 && this.exp > 1490) {
+            this.exp = 1490;
+        }
     }
 }

--- a/backend/src/main/java/com/aespa/nextplace/model/entity/User.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/entity/User.java
@@ -69,4 +69,16 @@ public class User {
     public void earnDalgona(int dalgona) {
         this.dalgona += dalgona;
     }
+
+    public boolean hasEnoughDalgona(int dalgona) {
+        return this.dalgona >= dalgona;
+    }
+
+    public boolean comsumeDalgona(int dalgona) {
+        if(!hasEnoughDalgona(dalgona)) {
+            return false;
+        }
+        this.dalgona -= dalgona;
+        return true;
+    }
 }

--- a/backend/src/main/java/com/aespa/nextplace/model/entity/User.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/entity/User.java
@@ -74,7 +74,7 @@ public class User {
         return this.dalgona >= dalgona;
     }
 
-    public boolean comsumeDalgona(int dalgona) {
+    public boolean consumeDalgona(int dalgona) {
         if(!hasEnoughDalgona(dalgona)) {
             return false;
         }

--- a/backend/src/main/java/com/aespa/nextplace/model/repository/ExperienceRepository.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/repository/ExperienceRepository.java
@@ -1,0 +1,9 @@
+package com.aespa.nextplace.model.repository;
+
+import com.aespa.nextplace.model.entity.Experience;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExperienceRepository extends JpaRepository<Experience, Integer> {
+    Experience findFirstByAccumulatedLessThanEqualOrderByLevelDesc(int accumulated);
+    Experience findByLevel(int level);
+}

--- a/backend/src/main/java/com/aespa/nextplace/model/request/PlamonLevelUpRequest.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/request/PlamonLevelUpRequest.java
@@ -1,0 +1,18 @@
+package com.aespa.nextplace.model.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PlamonLevelUpRequest {
+    @Schema(description = "레벨업하려는 캐릭터의 ID")
+    Long plamonId;
+
+    @Schema(description = "사용하려는 달고나 개수")
+    int dalgona;
+}

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonService.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonService.java
@@ -1,5 +1,6 @@
 package com.aespa.nextplace.service;
 
+import com.aespa.nextplace.model.request.PlamonLevelUpRequest;
 import com.aespa.nextplace.model.response.ListAllPlamonResponse;
 import com.aespa.nextplace.model.response.ListSellPlamonResponse;
 import com.aespa.nextplace.model.response.PlamonResponse;
@@ -8,4 +9,5 @@ public interface PlamonService {
     ListAllPlamonResponse findAllByUser(String oauthUid);
     PlamonResponse buyNewPlamonWithGold(String oauthUid);
     ListSellPlamonResponse sell(String oauthUid, Long plamonId);
+    PlamonResponse levelUpWithDalgona(String oauthUid, PlamonLevelUpRequest request);
 }

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
@@ -210,7 +210,7 @@ public class PlamonServiceImpl implements PlamonService {
         Experience nextLevel = expRepo.findFirstByAccumulatedLessThanEqualOrderByLevelDesc(nextExp);    //해당 경험치로 얻을 수 있는 다음 레벨 정의
 
         plamon.levelUp(nextExp, nextLevel);     //레벨 변화
-        user.comsumeDalgona(request.getDalgona());      //달고나 소모
+        user.consumeDalgona(request.getDalgona());      //달고나 소모
 
         return new PlamonResponse(plamon);
     }

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
@@ -29,7 +29,7 @@ public class PlamonServiceImpl implements PlamonService {
     private final PlamonRankUtil rankUtil;
     private final LevelUtil levelUtil;
 
-    public PlamonServiceImpl(PlamonRepository plamonRepo, PladexRepository pladexRepo, UserRepository userRepo, ExperienceRepository expRepo, LevelUtil levelUtil) {
+    public PlamonServiceImpl(PlamonRepository plamonRepo, PladexRepository pladexRepo, UserRepository userRepo, ExperienceRepository expRepo) {
         this.plamonRepo = plamonRepo;
         this.pladexRepo = pladexRepo;
         this.userRepo = userRepo;

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
@@ -1,15 +1,15 @@
 package com.aespa.nextplace.service;
 
-import com.aespa.nextplace.model.entity.Pladex;
-import com.aespa.nextplace.model.entity.Plamon;
-import com.aespa.nextplace.model.entity.PlamonRank;
-import com.aespa.nextplace.model.entity.User;
+import com.aespa.nextplace.model.entity.*;
+import com.aespa.nextplace.model.repository.ExperienceRepository;
 import com.aespa.nextplace.model.repository.PladexRepository;
 import com.aespa.nextplace.model.repository.PlamonRepository;
 import com.aespa.nextplace.model.repository.UserRepository;
+import com.aespa.nextplace.model.request.PlamonLevelUpRequest;
 import com.aespa.nextplace.model.response.ListAllPlamonResponse;
 import com.aespa.nextplace.model.response.ListSellPlamonResponse;
 import com.aespa.nextplace.model.response.PlamonResponse;
+import com.aespa.nextplace.util.LevelUtil;
 import com.aespa.nextplace.util.PlamonRankUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,13 +25,17 @@ public class PlamonServiceImpl implements PlamonService {
     private final PlamonRepository plamonRepo;
     private final PladexRepository pladexRepo;
     private final UserRepository userRepo;
+    private final ExperienceRepository expRepo;
     private final PlamonRankUtil rankUtil;
+    private final LevelUtil levelUtil;
 
-    public PlamonServiceImpl(PlamonRepository plamonRepo, PladexRepository pladexRepo, UserRepository userRepo) {
+    public PlamonServiceImpl(PlamonRepository plamonRepo, PladexRepository pladexRepo, UserRepository userRepo, ExperienceRepository expRepo, LevelUtil levelUtil) {
         this.plamonRepo = plamonRepo;
         this.pladexRepo = pladexRepo;
         this.userRepo = userRepo;
+        this.expRepo = expRepo;
         this.rankUtil = PlamonRankUtil.getInstance();
+        this.levelUtil = LevelUtil.getInstance();
     }
 
     public User findUserByOauthUid(String oauthUid){
@@ -170,5 +174,44 @@ public class PlamonServiceImpl implements PlamonService {
         ListAllPlamonResponse allByUser = findAllByUser(oauthUid);
 
         return new ListSellPlamonResponse(user.getDalgona(), allByUser.getMyPlamon(), allByUser.getNotMyPlamon());
+    }
+
+    /**
+     * 해당 달고나로 얻을 수 있는 경험치 계산
+     * 현재 플레몬의 레벨+경험치로 누적 경험치 계산(Plamon 접근 1)
+     * 플러스 경험치를 더했을 때 최종 누적 경험치 계산
+     * 경험치 테이블에서 변화될 레벨 조회(Experience 접근1)
+     * 해당 플레몬의 레벨, 경험치를 변화시킴(레벨 -> 변화된 레벨, 경험치 -> 현재 경험치 - 기준 경험치)
+     * */
+    @Override
+    @Transactional
+    public PlamonResponse levelUpWithDalgona(String oauthUid, PlamonLevelUpRequest request) throws IllegalArgumentException {
+        User user = findUserByOauthUid(oauthUid);
+
+        if (user == null) {
+            throw new IllegalArgumentException("존재하지 않는 유저입니다");
+        }
+
+        if (!user.hasEnoughDalgona(request.getDalgona())) {
+            throw new IllegalArgumentException("달고나가 부족합니다");
+        }
+
+        Plamon plamon = plamonRepo.findPlamonByUserAndId(user, request.getPlamonId());
+
+        if(plamon == null) {
+            throw  new IllegalArgumentException("존재하지 않는 캐릭터입니다");
+        }
+
+        Experience current = expRepo.findByLevel(plamon.getLevel());        // 현재 레벨에 해당하는 레벨 및 경험치 정보 조회
+
+        int plusExp = levelUtil.getExpValue(request.getDalgona());        //얻을 수 있는 경험치 계산
+        int nextExp = current.getAccumulated() + plamon.getExp() + plusExp;       //현재 경험치 + 얻은 경험치로 다음 경험치 계산
+
+        Experience nextLevel = expRepo.findFirstByAccumulatedLessThanEqualOrderByLevelDesc(nextExp);    //해당 경험치로 얻을 수 있는 다음 레벨 정의
+
+        plamon.levelUp(nextExp, nextLevel);     //레벨 변화
+        user.comsumeDalgona(request.getDalgona());      //달고나 소모
+
+        return new PlamonResponse(plamon);
     }
 }

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
@@ -199,7 +199,7 @@ public class PlamonServiceImpl implements PlamonService {
         Plamon plamon = plamonRepo.findPlamonByUserAndId(user, request.getPlamonId());
 
         if(plamon == null) {
-            throw  new IllegalArgumentException("존재하지 않는 캐릭터입니다");
+            throw  new IllegalStateException("존재하지 않는 캐릭터입니다");
         }
 
         Experience current = expRepo.findByLevel(plamon.getLevel());        // 현재 레벨에 해당하는 레벨 및 경험치 정보 조회

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
@@ -185,7 +185,7 @@ public class PlamonServiceImpl implements PlamonService {
      * */
     @Override
     @Transactional
-    public PlamonResponse levelUpWithDalgona(String oauthUid, PlamonLevelUpRequest request) throws IllegalArgumentException {
+    public PlamonResponse levelUpWithDalgona(String oauthUid, PlamonLevelUpRequest request) throws IllegalArgumentException, IllegalStateException {
         User user = findUserByOauthUid(oauthUid);
 
         if (user == null) {
@@ -193,7 +193,7 @@ public class PlamonServiceImpl implements PlamonService {
         }
 
         if (!user.hasEnoughDalgona(request.getDalgona())) {
-            throw new IllegalArgumentException("달고나가 부족합니다");
+            throw new IllegalStateException("달고나가 부족합니다");
         }
 
         Plamon plamon = plamonRepo.findPlamonByUserAndId(user, request.getPlamonId());

--- a/backend/src/main/java/com/aespa/nextplace/util/LevelUtil.java
+++ b/backend/src/main/java/com/aespa/nextplace/util/LevelUtil.java
@@ -4,13 +4,25 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class LevelUtil {
-    private final int expValue = 30;
+    private final int EXPVALUE = 30;
+    private final int MAXLEVEL = 15;
+    private final int MAXEXP = 1490;
 
     public static LevelUtil getInstance() {
         return LevelUtil.LazyHolder.instance;
     }
 
-    public int getExpValue(int dalgona) { return this.expValue * dalgona; }
+    public int getExpValue(int dalgona) {
+        return this.EXPVALUE * dalgona;
+    }
+
+    public int getMAXLEVEL() {
+        return MAXLEVEL;
+    }
+
+    public int getMAXEXP() {
+        return MAXEXP;
+    }
 
     private static class LazyHolder {
         private static final LevelUtil instance = new LevelUtil();

--- a/backend/src/main/java/com/aespa/nextplace/util/LevelUtil.java
+++ b/backend/src/main/java/com/aespa/nextplace/util/LevelUtil.java
@@ -1,0 +1,18 @@
+package com.aespa.nextplace.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class LevelUtil {
+    private final int expValue = 30;
+
+    public static LevelUtil getInstance() {
+        return LevelUtil.LazyHolder.instance;
+    }
+
+    public int getExpValue(int dalgona) { return this.expValue * dalgona; }
+
+    private static class LazyHolder {
+        private static final LevelUtil instance = new LevelUtil();
+    }
+}

--- a/backend/src/main/java/com/aespa/nextplace/util/PlamonRankUtil.java
+++ b/backend/src/main/java/com/aespa/nextplace/util/PlamonRankUtil.java
@@ -36,9 +36,10 @@ public class PlamonRankUtil {
         return this.gatchaProbability.size();
     }
 
-	public int getGatchaPrice() {
-		return this.gatchaPrice;
-	}
+    public int getGatchaPrice() {
+        return this.gatchaPrice;
+    }
+
 
     public int getProbabilityOfRank(PlamonRank rank) {
         return this.gatchaProbability.get(rank);

--- a/backend/src/test/java/com/aespa/nextplace/plamon/ExperienceRepositoryTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/plamon/ExperienceRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.aespa.nextplace.plamon;
+
+import com.aespa.nextplace.model.entity.Experience;
+import com.aespa.nextplace.model.repository.ExperienceRepository;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DataJpaTest
+@Disabled
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class ExperienceRepositoryTest {
+    @Autowired
+    ExperienceRepository expRepo;
+
+    @DisplayName("특정 경험치가 속하는 레벨 조회")
+    @Test
+    public void 경험치로레벨조회() throws Exception {
+        //given
+        int accumulated = 1265;
+
+        //when
+        Experience experience = expRepo.findFirstByAccumulatedLessThanEqualOrderByLevelDesc(accumulated);
+
+        //then
+        assertThat(experience.getLevel())
+                .isEqualTo(8);
+    }
+}

--- a/backend/src/test/java/com/aespa/nextplace/plamon/PlamonRepositoryTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/plamon/PlamonRepositoryTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 @DataJpaTest
+@Disabled
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class PlamonRepositoryTest {
     @Autowired private PlamonRepository plamonRepo;

--- a/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
@@ -460,4 +460,25 @@ class PlamonServiceTest {
         assertThat(response.getExp())
                 .isEqualTo(1490);
     }
+
+    @DisplayName("사용하려는 달고나 개수가 보유 개수보다 부족하다")
+    @Test
+    public void 달고나부족() throws Exception {
+        //given
+        User user = createUser("G-12345", 1000, 3);
+
+        given(userRepo.findByOauthUid(user.getOauthUid()))
+                .willReturn(user);
+
+        //when
+
+        IllegalStateException exception =
+                assertThrows(IllegalStateException.class,
+                        ()-> plamonService.levelUpWithDalgona(user.getOauthUid(), new PlamonLevelUpRequest(1L, 5)));
+
+        //then
+        assertThat(exception.getMessage())
+                .isEqualTo("달고나가 부족합니다");
+    }
+
 }

--- a/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
@@ -1,9 +1,11 @@
 package com.aespa.nextplace.plamon;
 
 import com.aespa.nextplace.model.entity.*;
+import com.aespa.nextplace.model.repository.ExperienceRepository;
 import com.aespa.nextplace.model.repository.PladexRepository;
 import com.aespa.nextplace.model.repository.PlamonRepository;
 import com.aespa.nextplace.model.repository.UserRepository;
+import com.aespa.nextplace.model.request.PlamonLevelUpRequest;
 import com.aespa.nextplace.model.response.ListAllPlamonResponse;
 import com.aespa.nextplace.model.response.ListSellPlamonResponse;
 import com.aespa.nextplace.model.response.PladexResponse;
@@ -46,6 +48,9 @@ class PlamonServiceTest {
     @Mock
     PladexRepository pladexRepo;
 
+    @Mock
+    ExperienceRepository expRepo;
+
     private Pladex createPladexOfId(long id) {
         return Pladex.builder()
                 .pladex(new Pladex("test", "test info", PlamonRank.SR))
@@ -60,61 +65,25 @@ class PlamonServiceTest {
                 .build();
     }
 
-    private Plamon createPlamonOfId(long id) {
+    private Plamon createPlamon(long id, int level, int exp, boolean main, PlamonRank rank) {
         return Plamon.builder()
                 .id(id)
-                .level(1)
-                .exp(10)
+                .level(level)
+                .exp(exp)
                 .nickname("랩실노예")
-                .isMain(false)
-                .pladex(createPladexOfId(1L))
-                .user(createUserOfUid("G-12345"))
-                .build();
-    }
-
-    private Plamon createPlamonOfIdAndRank(long id, PlamonRank rank) {
-        return Plamon.builder()
-                .id(id)
-                .level(1)
-                .exp(10)
-                .nickname("랩실노예")
-                .isMain(false)
+                .isMain(main)
                 .pladex(createPladexOfIdAndRank(1L, rank))
-                .user(createUserOfUid("G-12345"))
+                .user(createUser("G-12345", 1000, 10))
                 .build();
     }
 
-    private Plamon createPlamonOfIdAndMain(long id, boolean isMain) {
-        return Plamon.builder()
-                .id(id)
-                .level(1)
-                .exp(10)
-                .nickname("랩실노예")
-                .isMain(isMain)
-                .pladex(createPladexOfId(1L))
-                .user(createUserOfUid("G-12345"))
-                .build();
-    }
-
-    private User createUserOfUid(String uid) {
-        return User.builder()
-                .id(1L)
-                .user(new User(uid, "냉정한 고추참치"))
-                .role(UserRole.USER)
-                .gold(1000)
-                .dalgona(0)
-                .avatar(null)
-                .build();
-    }
-
-
-    private User createUserOfUidAndGold(String uid, int gold) {
+    private User createUser(String uid, int gold, int dalgona) {
         return User.builder()
                 .id(1L)
                 .user(new User(uid, "냉정한 고추참치"))
                 .role(UserRole.USER)
                 .gold(gold)
-                .dalgona(0)
+                .dalgona(dalgona)
                 .avatar(null)
                 .build();
     }
@@ -123,11 +92,11 @@ class PlamonServiceTest {
     @Test
     public void 소유구분해서뽑기() throws Exception {
         //given
-        User user = createUserOfUid("G-12345");
+        User user = createUser("G-12345", 0, 0);
         List<Plamon> plamons = List.of(
-                createPlamonOfIdAndRank(1L, PlamonRank.N),
-                createPlamonOfIdAndRank(2L, PlamonRank.N),
-                createPlamonOfIdAndRank(3L, PlamonRank.N)
+                createPlamon(1L, 1, 0, false, PlamonRank.N),
+                createPlamon(2L, 1, 0, false, PlamonRank.N),
+                createPlamon(3L, 1, 0, false, PlamonRank.N)
         );
         List<Pladex> pladexes = List.of(
                 createPladexOfIdAndRank(2L, PlamonRank.SSR),
@@ -254,7 +223,7 @@ class PlamonServiceTest {
     @Test
     public void 플레몬뽑기() throws IllegalArgumentException {
         //given
-        User user = createUserOfUid("G-12345");
+        User user = createUser("G-12345", 1000, 0);
         List<Pladex> pladexList = List.of(
                 createPladexOfIdAndRank(1L, PlamonRank.N),
                 createPladexOfIdAndRank(2L, PlamonRank.N),
@@ -292,7 +261,7 @@ class PlamonServiceTest {
     @Test
     public void 플레몬뽑기골드부족() throws IllegalArgumentException {
         //given
-        User user = createUserOfUidAndGold("G-12345", 50);
+        User user = createUser("G-12345", 50, 0);
         given(userRepo.findByOauthUid("G-12345"))
                 .willReturn(user);
 
@@ -309,7 +278,7 @@ class PlamonServiceTest {
     @Test
     public void 캐릭터인증() throws Exception {
         //given
-        User user = createUserOfUid("B-12345");
+        User user = createUser("B-12345", 0, 0);
         given(userRepo.findByOauthUid("B-12345"))
                 .willReturn(null);
 
@@ -325,13 +294,13 @@ class PlamonServiceTest {
     @Test
     public void 캐릭터팔기() throws Exception {
         //given
-        User user = createUserOfUid("G-12345");
+        User user = createUser("G-12345", 1000, 0);
         int preDalgona = user.getDalgona();
         List<Plamon> afterPlamons = List.of(
-                createPlamonOfId(1L),
-                createPlamonOfId(3L)
+                createPlamon(1L, 1, 0, false, PlamonRank.SR),
+                createPlamon(3L, 1, 0, false, PlamonRank.SR)
         );
-        Plamon sellingPlamon = createPlamonOfIdAndRank(2L, PlamonRank.SR);
+        Plamon sellingPlamon = createPlamon(2L, 1, 0, false, PlamonRank.SR);
         given(userRepo.findByOauthUid("G-12345"))
                 .willReturn(user);
         given(plamonRepo.findPlamonByUserAndId(user, 2L))
@@ -370,7 +339,7 @@ class PlamonServiceTest {
     @Test
     public void 미소유캐릭터팔기() throws Exception {
         //given
-        User user = createUserOfUid("G-12345");
+        User user = createUser("G-12345", 1000, 0);
         given(userRepo.findByOauthUid("G-12345"))
                 .willReturn(user);
         given(plamonRepo.findPlamonByUserAndId(user, 2L))
@@ -390,8 +359,8 @@ class PlamonServiceTest {
     @Test
     public void 대표캐릭터팔기() throws Exception {
         //given
-        User user = createUserOfUid("G-12345");
-        Plamon sellingPlamon = createPlamonOfIdAndMain(2L, true);
+        User user = createUser("G-12345", 1000, 0);
+        Plamon sellingPlamon = createPlamon(2L, 1, 0, true, PlamonRank.N);
         given(userRepo.findByOauthUid("G-12345"))
                 .willReturn(user);
         given(plamonRepo.findPlamonByUserAndId(user, 2L))
@@ -408,4 +377,87 @@ class PlamonServiceTest {
                 .isEqualTo("대표 캐릭터는 삭제할 수 없습니다");
     }
 
+    @DisplayName("캐릭터를 1레벨 업한다")
+    @Test
+    public void 레벨업_1() throws Exception {
+        //given
+        User user = createUser("G-12345", 1000, 30);
+        Plamon plamon = createPlamon(1L, 1, 0, false, PlamonRank.SR);
+        Experience next = new Experience(2, 15, 34);
+        Experience cur = new Experience(1, 0, 15);
+
+        given(userRepo.findByOauthUid(user.getOauthUid()))
+                .willReturn(user);
+        given(plamonRepo.findPlamonByUserAndId(user, plamon.getId()))
+                .willReturn(plamon);
+        given(expRepo.findFirstByAccumulatedLessThanEqualOrderByLevelDesc(30))
+                .willReturn(next);
+        given(expRepo.findByLevel(1))
+                .willReturn(cur);
+
+        //when
+        PlamonResponse response = plamonService.levelUpWithDalgona(user.getOauthUid(), new PlamonLevelUpRequest(plamon.getId(), 1));
+
+        //then
+        assertThat(response.getLevel())
+                .isEqualTo(2);
+        assertThat(response.getExp())
+                .isEqualTo(15);
+    }
+
+    @DisplayName("캐릭터를 3레벨 업한다")
+    @Test
+    public void 레벨업_3() throws Exception {
+        //given
+        User user = createUser("G-12345", 1000, 30);
+        Plamon plamon = createPlamon(1L, 3, 1, false, PlamonRank.SR);
+        Experience next = new Experience(6, 333, 372);
+        Experience cur = new Experience(3, 49, 57);
+
+        given(userRepo.findByOauthUid(user.getOauthUid()))
+                .willReturn(user);
+        given(plamonRepo.findPlamonByUserAndId(user, plamon.getId()))
+                .willReturn(plamon);
+        given(expRepo.findFirstByAccumulatedLessThanEqualOrderByLevelDesc(380))
+                .willReturn(next);
+        given(expRepo.findByLevel(3))
+                .willReturn(cur);
+
+        //when
+        PlamonResponse response = plamonService.levelUpWithDalgona(user.getOauthUid(), new PlamonLevelUpRequest(plamon.getId(), 11));
+
+        //then
+        assertThat(response.getLevel())
+                .isEqualTo(6);
+        assertThat(response.getExp())
+                .isEqualTo(47);
+    }
+
+    @DisplayName("최대 레벨 이상의 레벨업을 시도한다")
+    @Test
+    public void 레벨업_MAX() throws Exception {
+        //given
+        User user = createUser("G-12345", 1000, 50000);
+        Plamon plamon = createPlamon(1L, 3, 1, false, PlamonRank.SR);
+        Experience next = new Experience(15, 9557, 1490);
+        Experience cur = new Experience(3, 49, 57);
+
+        given(userRepo.findByOauthUid(user.getOauthUid()))
+                .willReturn(user);
+        given(plamonRepo.findPlamonByUserAndId(user, plamon.getId()))
+                .willReturn(plamon);
+        given(expRepo.findFirstByAccumulatedLessThanEqualOrderByLevelDesc(30050))
+                .willReturn(next);
+        given(expRepo.findByLevel(3))
+                .willReturn(cur);
+
+        //when
+        PlamonResponse response = plamonService.levelUpWithDalgona(user.getOauthUid(), new PlamonLevelUpRequest(plamon.getId(), 1000));
+
+        //then
+        assertThat(response.getLevel())
+                .isEqualTo(15);
+        assertThat(response.getExp())
+                .isEqualTo(1490);
+    }
 }


### PR DESCRIPTION
## Motivation 🤔

- 유저가 가진 달고나를 사용해서 캐릭터의 레벨과 경험치를 올릴 수 있는 기능입니다
- 한 번에 레벨을 여러 번 업할 수 있습니다 (ex. level 1 -> 4)
- 레벨 업에 필요한 정보(특정 레벨의 누적 경험치, 경험치 보정양)는 메이플스토리 경험치 표를 참고했습니다
- 수행 뒤 달고나 개수, 해당 캐릭터의 레벨, 경험치가 변화합니다

<br>

## Key Changes 🔑

- DB의 Experience 테이블을 이용해서 누적 경험치에 해당하는 레벨을 조회하고, 특정 레벨의 경험치 정보를 알 수 있도록 했습니다
- 자신이 가진 캐릭터가 아닐 경우/사용하려는 달고나 개수가 보유 개수보다 부족할 경우 예외를 반환합니다
- Service Test 클래스의 경우 인스턴스를 생성해서 반환하는 메서드를 정리했습니다
- Repository Test 클래스는 쿼리 메서드 테스트 용도로 시험적으로 사용하되 PR할 때는 disable해서 테스트 시간을 단축하도록 했습니다.

<br>

## To Reviewers 🙏
- 유저가 인증되지 않은 경우 현재까지는 `IllegalArgumentException`을 반환해주고 있었는데, 아래와 같이 Exception을 정의해주는 것이 더 명확할 것 같다고 느꼈습니다. 예외 종류에 맞는 Exception을 찾기가 애매하다고 느껴서 경원님 의견이 궁금하네요 ..
```java
@ResponseStatus(value = HttpStatus.UNAUTHORIZED, reason = "Unauthorized")
public class UnauthorizedException extends RuntimeException {
    public UnauthorizedException(String message) {
        super(message);
    }
}
```
- Plamon 도메인에 너무 많은 비즈니스 로직이 생기다보니 서비스 클래스가 무거워진 감이 있어서 캐릭터 거래 파트를 분리할 지 생각중입니다. 이 부분도 피드백 남겨주세용