### PR TITLE
Close #91 - 대표 캐릭터 조회하기

### DIFF
--- a/backend/src/main/java/com/aespa/nextplace/controller/PlamonController.java
+++ b/backend/src/main/java/com/aespa/nextplace/controller/PlamonController.java
@@ -8,6 +8,8 @@ import com.aespa.nextplace.model.response.PlamonResponse;
 import com.aespa.nextplace.service.PlamonService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.parser.ParseException;
@@ -103,6 +105,22 @@ public class PlamonController {
                     .body(new ErrorResponse(e.getMessage()));
         } catch (IllegalStateException e) {         // 달고나 부족 or 존재하지 않는 캐릭터
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ErrorResponse(e.getMessage()));
+        }
+    }
+
+    @GetMapping("/main")
+    @Operation(summary = "내 대표 캐릭터 조회", description = "유저의 대표 캐릭터를 조회한다", responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation= PlamonResponse.class)))
+    })
+    public ResponseEntity<?> readMyMainPlamon() {
+        String oauthUid = "G-12345";
+        try {
+            PlamonResponse myMainPlamon = plamonService.getMyMainPlamon(oauthUid);
+
+            return ResponseEntity.ok(myMainPlamon);
+        } catch (IllegalArgumentException e) {      // 유저 정보 없음
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(new ErrorResponse(e.getMessage()));
         }
     }

--- a/backend/src/main/java/com/aespa/nextplace/model/repository/PlamonRepository.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/repository/PlamonRepository.java
@@ -3,6 +3,8 @@ package com.aespa.nextplace.model.repository;
 import com.aespa.nextplace.model.entity.Plamon;
 import com.aespa.nextplace.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,5 +12,12 @@ import java.util.List;
 @Repository
 public interface PlamonRepository extends JpaRepository<Plamon, Long> {
     List<Plamon> findAllByUser(User user);
+
     Plamon findPlamonByUserAndId(User user, Long id);
+
+    @Query("select m from Plamon m where m.user = :user and m.isMain = true")
+    Plamon findPlamonByUserAndMainIsTrue(@Param("user") User user);
+
+    @Query("select m from Plamon m where m.id = 16L")
+    Plamon findDefaultPlamon();
 }

--- a/backend/src/main/java/com/aespa/nextplace/model/repository/PlamonRepository.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/repository/PlamonRepository.java
@@ -18,6 +18,6 @@ public interface PlamonRepository extends JpaRepository<Plamon, Long> {
     @Query("select m from Plamon m where m.user = :user and m.isMain = true")
     Plamon findPlamonByUserAndMainIsTrue(@Param("user") User user);
 
-    @Query("select m from Plamon m where m.id = 16L")
+    @Query("select m from Plamon m where m.pladex.id = 16L")
     Plamon findDefaultPlamon();
 }

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonService.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonService.java
@@ -10,4 +10,5 @@ public interface PlamonService {
     PlamonResponse buyNewPlamonWithGold(String oauthUid);
     ListSellPlamonResponse sell(String oauthUid, Long plamonId);
     PlamonResponse levelUpWithDalgona(String oauthUid, PlamonLevelUpRequest request);
+    PlamonResponse getMyMainPlamon(String oauthUid);
 }

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
@@ -216,7 +216,7 @@ public class PlamonServiceImpl implements PlamonService {
     }
 
     @Override
-    public PlamonResponse getMyMainPlamon(String oauthUid) {
+    public PlamonResponse getMyMainPlamon(String oauthUid) throws IllegalArgumentException{
         User user = findUserByOauthUid(oauthUid);
 
         if (user == null) {

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
@@ -214,4 +214,9 @@ public class PlamonServiceImpl implements PlamonService {
 
         return new PlamonResponse(plamon);
     }
+
+    @Override
+    public PlamonResponse getMyMainPlamon(String oauthUid) {
+        return null;
+    }
 }

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
@@ -217,6 +217,19 @@ public class PlamonServiceImpl implements PlamonService {
 
     @Override
     public PlamonResponse getMyMainPlamon(String oauthUid) {
-        return null;
+        User user = findUserByOauthUid(oauthUid);
+
+        if (user == null) {
+            throw new IllegalArgumentException("존재하지 않는 유저입니다");
+        }
+
+        Plamon mainPlamon = plamonRepo.findPlamonByUserAndMainIsTrue(user);
+
+        if(mainPlamon == null) {    // 대표 캐릭터가 없음
+            Plamon defaultMainPlamon = plamonRepo.findDefaultPlamon();
+            return new PlamonResponse(defaultMainPlamon);
+        }
+
+        return new PlamonResponse(mainPlamon);
     }
 }

--- a/backend/src/test/java/com/aespa/nextplace/plamon/PlamonRepositoryTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/plamon/PlamonRepositoryTest.java
@@ -4,7 +4,6 @@ import com.aespa.nextplace.model.entity.Plamon;
 import com.aespa.nextplace.model.entity.User;
 import com.aespa.nextplace.model.repository.PlamonRepository;
 import com.aespa.nextplace.model.repository.UserRepository;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 @DataJpaTest
-@Disabled
+//@Disabled
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class PlamonRepositoryTest {
     @Autowired private PlamonRepository plamonRepo;
@@ -29,7 +28,6 @@ public class PlamonRepositoryTest {
     @DisplayName("캐릭터를 판매했을 때 정상적으로 삭제되는지 검증")
     @Test
     @Transactional
-    @Disabled
     public void 데이터삭제() throws Exception {
         //given
         User user = userRepo.findByOauthUid("G-12345");
@@ -48,5 +46,19 @@ public class PlamonRepositoryTest {
         //then
         assertThat(plamonRepo.count())
                 .isEqualTo(size-1);
+    }
+
+    @DisplayName("대표 캐릭터 조회")
+    @Test
+    public void 대표_캐릭터() throws Exception {
+        //given
+        User user = userRepo.findByOauthUid("G-12345");
+
+        //when
+        Plamon plamon = plamonRepo.findPlamonByUserAndMainIsTrue(user);
+
+        //then
+        assertThat(plamon.isMain())
+                .isEqualTo(true);
     }
 }

--- a/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
@@ -481,4 +481,55 @@ class PlamonServiceTest {
                 .isEqualTo("달고나가 부족합니다");
     }
 
+    @DisplayName("내 대표 캐릭터 조회")
+    @Test
+    public void 대표캐릭터() throws Exception {
+        //given
+        User user = createUser("G-12345", 1000, 3);
+        Plamon plamon = createPlamon(1L, 1, 0, true, PlamonRank.SR);
+
+        given(userRepo.findByOauthUid(user.getOauthUid()))
+                .willReturn(user);
+        given(plamonRepo.findPlamonByUserAndMainIsTrue(user))
+                .willReturn(plamon);
+
+        //when
+        PlamonResponse response = plamonService.getMyMainPlamon(user.getOauthUid());
+
+        //then
+        assertThat(response.isMain())
+                .isEqualTo(true);
+        verify(userRepo).findByOauthUid(user.getOauthUid());
+        verify(plamonRepo).findPlamonByUserAndMainIsTrue(user);
+    }
+
+    @DisplayName("대표 캐릭터가 없음")
+    @Test
+    public void 대표캐릭터_없음() throws Exception {
+        //given
+        User user = createUser("G-12345", 1000, 3);
+        Plamon plamon = createPlamon(1L, 1, 0, true, PlamonRank.SR);
+        Plamon defaultPlamon = createPlamon(16L, 1, 0, true, PlamonRank.SSR);
+
+        given(userRepo.findByOauthUid(user.getOauthUid()))
+                .willReturn(user);
+        given(plamonRepo.findPlamonByUserAndMainIsTrue(user))
+                .willReturn(null);
+        given(plamonRepo.findDefaultPlamon())
+                .willReturn(defaultPlamon);
+
+        //when
+        PlamonResponse response = plamonService.getMyMainPlamon(user.getOauthUid());
+
+        //then
+        assertThat(response.isMain())
+                .isEqualTo(true);
+        assertThat(response.getId())
+                .isEqualTo(16L);
+        verify(userRepo).findByOauthUid(user.getOauthUid());
+        verify(plamonRepo).findPlamonByUserAndMainIsTrue(user);
+        verify(plamonRepo).findDefaultPlamon();
+    }
+
+
 }


### PR DESCRIPTION
## Motivation 🤔

- [GET] /plamon/main
- 내가 가진 캐릭터 중에 main 필드가 true인 캐릭터를 반환한다
- 만약 없다면 기본 캐릭터를 반환한다

<br>

## Key Changes 🔑

![image](https://user-images.githubusercontent.com/30489264/141732002-ae93640c-d70d-41b4-8ddc-4b815a09b21b.png)

- DB에 기본 캐릭터 데이터를 넣어두고, main이 true인 캐릭터를 찾은 뒤 없다면 기본 캐릭터를 조회해서 반환하도록 구현했습니다
