### PR TITLE
Close #128 - 내가 가지지 않은 캐릭터 조회 버그 수정

### DIFF
--- a/backend/src/main/java/com/aespa/nextplace/model/repository/PladexRepository.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/repository/PladexRepository.java
@@ -18,7 +18,10 @@ public interface PladexRepository extends JpaRepository<Pladex, Long> {
     @Query("select d from Pladex d where d.name <> '기본캐릭터'")
     List<Pladex> findAllByRank(PlamonRank rank);
 
-    @Query("select distinct d from Pladex d left outer join Plamon m on m.pladex=d where m.user <> :user or m.pladex is null")
+    @Query("select distinct d from Pladex d " +
+            "left outer join Plamon m on m.pladex = d " +
+            "where m.pladex is null or " +
+            "m.pladex not in (select m.pladex from Plamon m where m.user = :user)")
     List<Pladex> findAllByUserWithNotMine(@Param("user") User user);
 
     @Query("select d from Pladex d where d.name = '기본캐릭터'")

--- a/backend/src/test/java/com/aespa/nextplace/pladex/PladexRepositoryTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/pladex/PladexRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.aespa.nextplace.pladex;
+
+import com.aespa.nextplace.model.entity.Pladex;
+import com.aespa.nextplace.model.entity.User;
+import com.aespa.nextplace.model.repository.PladexRepository;
+import com.aespa.nextplace.model.repository.UserRepository;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DataJpaTest
+@Disabled
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class PladexRepositoryTest {
+    @Autowired private PladexRepository pladexRepo;
+    @Autowired private UserRepository userRepo;
+
+
+    @DisplayName("내가 안 가진 캐릭터 조회")
+    @Test
+    void 내가_안가진_캐릭터_조회() {
+        //given
+        User user = userRepo.findByOauthUid("G-12345");
+
+        //when
+        List<Pladex> notMine = pladexRepo.findAllByUserWithNotMine(user);
+
+        //then
+        for (Pladex pladex: notMine) {
+            System.out.println(pladex.toString());
+        }
+        assertThat(notMine.size())
+                .isEqualTo(2);
+    }
+}


### PR DESCRIPTION
## Motivation 🤔

- 내가 가진 캐릭터가 남도 가지고 있으면 가지지 않은 캐릭터 리스트에 포함되는 버그를 발견했습니다

<br>

## Key Changes 🔑

- 조회하는 쿼리문에서 1️⃣ 내가 가진 캐릭터 번호 목록에 속하지 않은 번호 2️⃣ 아무도 가지지 않은 캐릭터 두 종류를 조회하도록 했습니다
  - 2번의 쿼리문인 `m.pladex is null`이 빠져도 되지 않을까 라고 생각했지만 그 부분을 제거하니까 의도한 결과가 나오지 않는다는걸 알았습니다 
