### PR TITLE
Feat/spot cache

### DIFF
--- a/backend/src/main/java/com/aespa/nextplace/NextplaceApplication.java
+++ b/backend/src/main/java/com/aespa/nextplace/NextplaceApplication.java
@@ -1,13 +1,24 @@
 package com.aespa.nextplace;
 
+import java.util.TimeZone;
+
+import javax.annotation.PostConstruct;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 @SpringBootApplication
 @EnableAspectJAutoProxy
+@EnableCaching
 public class NextplaceApplication {
-
+	
+	@PostConstruct
+    void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
+	
 	public static void main(String[] args) {
 		SpringApplication.run(NextplaceApplication.class, args);
 	}

--- a/backend/src/main/java/com/aespa/nextplace/config/CacheConfig.java
+++ b/backend/src/main/java/com/aespa/nextplace/config/CacheConfig.java
@@ -1,0 +1,39 @@
+package com.aespa.nextplace.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+public class CacheConfig {
+  
+  @Autowired
+  RedisConnectionFactory redisConnectionFactory;
+  
+  @Autowired
+  ObjectMapper objectMapper;
+  
+  @Autowired
+  RedisConnectionFactory connectionFactory;
+  
+  
+  @Bean
+  public CacheManager redisCacheManager() {
+    RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+      .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+      .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+    
+    RedisCacheManager redisCacheManager = RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory).cacheDefaults(redisCacheConfiguration).build();
+    return redisCacheManager;
+  }
+  
+}

--- a/backend/src/main/java/com/aespa/nextplace/config/RedisConfig.java
+++ b/backend/src/main/java/com/aespa/nextplace/config/RedisConfig.java
@@ -1,0 +1,45 @@
+package com.aespa.nextplace.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+public class RedisConfig {
+  
+  @Value("${spring.redis.port}")
+  public int port;
+  
+  @Value("${spring.redis.host}")
+  public String host;
+  
+  @Autowired
+  public ObjectMapper objectMapper;
+  
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+    redisTemplate.setConnectionFactory(connectionFactory);
+    return redisTemplate;
+  }
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+    redisStandaloneConfiguration.setHostName(host);
+    redisStandaloneConfiguration.setPort(port);
+    LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
+    return connectionFactory;
+  }
+}

--- a/backend/src/main/java/com/aespa/nextplace/controller/SpotController.java
+++ b/backend/src/main/java/com/aespa/nextplace/controller/SpotController.java
@@ -37,7 +37,9 @@ public class SpotController {
     	String oauthUid = (String) request.getAttribute("uid");    
     	
     	try {
-    		response = spotService.getSpots(oauthUid,lat, lng);
+    		String address = spotService.getRealAddress(lat, lng);
+    		response = spotService.getSpotsFromAddress(address);
+    		response = spotService.getSpots(oauthUid, response);
     	} catch(IllegalArgumentException e) {
     		return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
     	}

--- a/backend/src/main/java/com/aespa/nextplace/model/entity/Spot.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/entity/Spot.java
@@ -55,6 +55,11 @@ public class Spot {
     @Column(name = "spot_exp")
     private int exp;
     
+    
+	public boolean getIsRandom() {
+		return isRandom;
+	}
+	    
     public Spot(BaseAddress baseAddess,String name, float lat, float lng) {
     	this.baseAddress = baseAddess;
     	this.name = name;

--- a/backend/src/main/java/com/aespa/nextplace/model/response/ListSpotResponse.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/response/ListSpotResponse.java
@@ -6,23 +6,25 @@ import java.util.List;
 import com.aespa.nextplace.model.entity.Spot;
 import com.aespa.nextplace.util.RedisUtil;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ListSpotResponse {
-	private List<SpotResponse> spotList;
+	private List<SpotResponse> spotList = new ArrayList<>();
 	
 	public ListSpotResponse(List<Spot> spots) {
 		for(Spot spot : spots) {
 			spotList.add(new SpotResponse(spot));
 		}
-	}
+	}	
 	
-	public ListSpotResponse(List<Spot> spots, String oauthUid,RedisUtil redisUtil) {
-		this.spotList = new ArrayList<>();
-		for(Spot spot : spots) {
-			if(redisUtil.getData(oauthUid+"+"+spot.getId())==null) {			
-				spotList.add(new SpotResponse(spot));
+	public ListSpotResponse(ListSpotResponse response, String oauthUid,RedisUtil redisUtil) {
+		for(SpotResponse spotResponse : response.getSpotList()) {
+			if(redisUtil.getData(oauthUid+"+"+spotResponse.getId())==null) {			
+				spotList.add(spotResponse);
 			}
 		}
 	}

--- a/backend/src/main/java/com/aespa/nextplace/model/response/SpotResponse.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/response/SpotResponse.java
@@ -4,9 +4,12 @@ import com.aespa.nextplace.model.entity.Spot;
 import com.aespa.nextplace.model.entity.SpotType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SpotResponse {
 	
 	@Schema(example="1")
@@ -27,12 +30,17 @@ public class SpotResponse {
 	@Schema(example="127.343")
 	private float lng;	
 	
+	public boolean getIsRandom() {
+		return isRandom;
+	}
+	
+	
 	public SpotResponse(Spot spot) {
 		this.id = spot.getId();
 		this.name = spot.getName();
 		this.information = spot.getInformation();
 		this.detail = spot.getDetail();
-		this.isRandom = spot.isRandom();
+		this.isRandom = spot.getIsRandom();
 		this.lat = spot.getLat();
 		this.lng = spot.getLng();
 		this.type = spot.getType();

--- a/backend/src/main/java/com/aespa/nextplace/service/SpotService.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/SpotService.java
@@ -2,6 +2,8 @@ package com.aespa.nextplace.service;
 
 import com.aespa.nextplace.model.response.ListSpotResponse;
 
-public interface SpotService {
-	ListSpotResponse getSpots(String oauthUid, String lat, String lng);
+public interface SpotService {	
+	String getRealAddress(String lat, String lng);
+	ListSpotResponse getSpotsFromAddress(String realAddress);
+	ListSpotResponse getSpots(String oauthUid, ListSpotResponse listSpotResponse);
 }

--- a/backend/src/test/java/com/aespa/nextplace/spot/SpotServiceTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/spot/SpotServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.aespa.nextplace.model.entity.BaseAddress;
@@ -22,6 +23,7 @@ import com.aespa.nextplace.model.entity.SpotType;
 import com.aespa.nextplace.model.repository.PlactionRepository;
 import com.aespa.nextplace.model.repository.SpotRepository;
 import com.aespa.nextplace.model.repository.UserRepository;
+import com.aespa.nextplace.model.response.ErrorResponse;
 import com.aespa.nextplace.model.response.ListSpotResponse;
 import com.aespa.nextplace.model.response.SpotResponse;
 import com.aespa.nextplace.service.SpotServiceImpl;
@@ -96,7 +98,14 @@ public class SpotServiceTest {
 		
 		
 		//when		
-		ListSpotResponse response = spotService.getSpots(oauthUid,lat,lng);
+		ListSpotResponse response = null;
+		try {
+    		String address = spotService.getRealAddress(lat, lng);
+    		response = spotService.getSpotsFromAddress(address);
+    		response = spotService.getSpots(oauthUid, response);
+    	} catch(IllegalArgumentException e) {
+    		ex = e;
+    	}
 		
 		
 		//then
@@ -116,18 +125,16 @@ public class SpotServiceTest {
 	@Test
 	void 잘못된_좌표() throws Exception{
 		//given
-		String oauthUid = "G-12345";
 		String lat = "500", lng = "100";
 		
 
 		
 		//when
 		try {
-			spotService.getSpots(oauthUid,lat,lng);					
-		}
-		catch(IllegalArgumentException e){
-			ex = e;
-		}
+    		spotService.getRealAddress(lat, lng);
+    	} catch(IllegalArgumentException e) {
+    		ex = e;
+    	}
 		
 		
 		//then
@@ -147,13 +154,15 @@ public class SpotServiceTest {
 		given(geocodeUtil.getAddress(lat, lng))
 		.willReturn("");
 		
-		//when
+		//when		
+		ListSpotResponse response = null;
 		try {
-			spotService.getSpots(oauthUid,lat,lng);					
-		}
-		catch(IllegalArgumentException e){
-			ex = e;
-		}
+    		String address = spotService.getRealAddress(lat, lng);
+    		response = spotService.getSpotsFromAddress(address);
+    		response = spotService.getSpots(oauthUid, response);
+    	} catch(IllegalArgumentException e) {
+    		ex = e;
+    	}
 		
 		
 		//then
@@ -188,8 +197,15 @@ public class SpotServiceTest {
 		
 		
 		//when
-		
-		ListSpotResponse response = spotService.getSpots(oauthUid,lat,lng);
+		//when		
+		ListSpotResponse response = null;
+		try {
+    		String address = spotService.getRealAddress(lat, lng);
+    		response = spotService.getSpotsFromAddress(address);
+    		response = spotService.getSpots(oauthUid, response);
+    	} catch(IllegalArgumentException e) {
+    		ex = e;
+    	}
 		
 		
 		//then


### PR DESCRIPTION
## Motivation 🤔
- 스팟들을 가져올 때, 법정동 기준으로 캐싱하여 캐시 데이터가 있는 경우 DB가 아닌 캐시 데이터에서 가져옵니다.

<br>

## Key Changes 🔑
- SpotService의 getSpotsFromAddress 함수를 캐싱하였습니다.
- 법정동 단위로 데이터를 캐싱하였습니다.
- 서비스에서 스팟을 받아오는 함수였던 getSpots를 다음 3가지 기능으로 분리하였습니다.
  - 좌표로 주소를 받아오는 기능
  - 받아온 주소로 그 지역 스팟 목록을 받아오는 기능
  - 받아온 스팟 목록 중에서 유저가 점수를 획득할 수 없는 스팟을 거르는 기능
- 다음과 같이 기능을 나눈 이유는 @Cacheable이 붙은 메소드가 캐싱이 가능한데, @Cacheable이 붙지 않은 메소드에서 이 메소드를 호출하는 경우 캐싱 기능이 적용되지 않기 때문에 캐싱이 필요한 부분만 캐싱하기 위해 분리하였습니다.

<br>

## To Reviewers 🙏
- 현재 Cache를 비우는 부분이 없습니다. 2가지 방법으로 비우는 방법이 있습니다.
  - 하나는, 스케쥴러를 이용하여 주기적으로 모든 Redis 키 값을 조회하여 매칭되는 키 값을 찾아서 제거하는 방법
  - 다른 하나는, Spot이 갱신될 때 캐시를 초기화하는 방법입니다.
- 첫 번째 방법은 key를 All Scan 하는 것이기 때문에 매우 비효율적이라고 생각하여 적용하지 않았습니다.
- 두 번째 방법은 현재 관리자 기능이 없기 때문에 추후에 관리자 기능이 생긴다면 그 때 적용하면 될 것 같습니다.
