### PR TITLE
Close #134 - PlamonService 분리

### DIFF
--- a/backend/src/main/java/com/aespa/nextplace/controller/PlamonController.java
+++ b/backend/src/main/java/com/aespa/nextplace/controller/PlamonController.java
@@ -6,6 +6,7 @@ import com.aespa.nextplace.model.response.ErrorResponse;
 import com.aespa.nextplace.model.response.ListAllPlamonResponse;
 import com.aespa.nextplace.model.response.ListSellPlamonResponse;
 import com.aespa.nextplace.model.response.PlamonResponse;
+import com.aespa.nextplace.service.PlamonDealService;
 import com.aespa.nextplace.service.PlamonService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,6 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 @RequiredArgsConstructor
 public class PlamonController {
     private final PlamonService plamonService;
+    private final PlamonDealService plamonDealService;
 
     @GetMapping("")
     @Operation(summary = "내 캐릭터 조회", description = "유저가 소유한 캐릭터 목록을 조회한다", responses = {
@@ -55,7 +57,7 @@ public class PlamonController {
         String oauthUid = (String) httpServletReq.getAttribute("uid");
 
         try {
-            response = plamonService.buyNewPlamonWithGold(oauthUid);
+            response = plamonDealService.buyNewPlamonWithGold(oauthUid);
         } catch (IllegalArgumentException e) {      // 유저 정보 없음
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(new ErrorResponse(e.getMessage()));
@@ -80,7 +82,7 @@ public class PlamonController {
         String oauthUid = (String) httpServletReq.getAttribute("uid");
 
         try {
-            ListSellPlamonResponse response = plamonService.sell(oauthUid, plamonId);
+            ListSellPlamonResponse response = plamonDealService.sell(oauthUid, plamonId);
             return ResponseEntity.ok(response);
         } catch (IllegalArgumentException e) {      // 유저 정보 없음
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonDealService.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonDealService.java
@@ -1,0 +1,15 @@
+package com.aespa.nextplace.service;
+
+import com.aespa.nextplace.model.entity.User;
+import com.aespa.nextplace.model.response.ListAllPlamonResponse;
+import com.aespa.nextplace.model.response.ListSellPlamonResponse;
+import com.aespa.nextplace.model.response.PlamonResponse;
+
+public interface PlamonDealService {
+    User findUserByOauthUid(String oauthUid);
+
+    ListAllPlamonResponse findAllByUser(String oauthUid);
+
+    PlamonResponse buyNewPlamonWithGold(String oauthUid);
+    ListSellPlamonResponse sell(String oauthUid, Long plamonId);
+}

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonDealServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonDealServiceImpl.java
@@ -1,0 +1,179 @@
+package com.aespa.nextplace.service;
+
+import com.aespa.nextplace.model.entity.Pladex;
+import com.aespa.nextplace.model.entity.Plamon;
+import com.aespa.nextplace.model.entity.PlamonRank;
+import com.aespa.nextplace.model.entity.User;
+import com.aespa.nextplace.model.repository.PladexRepository;
+import com.aespa.nextplace.model.repository.PlamonRepository;
+import com.aespa.nextplace.model.repository.UserRepository;
+import com.aespa.nextplace.model.response.ListAllPlamonResponse;
+import com.aespa.nextplace.model.response.ListSellPlamonResponse;
+import com.aespa.nextplace.model.response.PlamonResponse;
+import com.aespa.nextplace.util.PlamonRankUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Random;
+
+@Service
+@Transactional(readOnly = true)
+public class PlamonDealServiceImpl implements PlamonDealService{
+    private static final String UNAUTHORIZED_USER_MESSAGE = "존재하지 않는 유저입니다";
+    private final PlamonRepository plamonRepo;
+    private final PladexRepository pladexRepo;
+    private final UserRepository userRepo;
+    private final PlamonRankUtil rankUtil;
+    private final Random random;
+
+    public PlamonDealServiceImpl(PlamonRepository plamonRepo, PladexRepository pladexRepo, UserRepository userRepo) {
+        this.plamonRepo = plamonRepo;
+        this.pladexRepo = pladexRepo;
+        this.userRepo = userRepo;
+        this.rankUtil = PlamonRankUtil.getInstance();
+        this.random = new Random();
+    }
+
+    @Override
+    public User findUserByOauthUid(String oauthUid){
+        return userRepo.findByOauthUid(oauthUid);
+    }
+
+    @Override
+    public ListAllPlamonResponse findAllByUser(String oauthUid) {
+        User user = findUserByOauthUid(oauthUid);
+
+        if (user == null) {
+            throw new IllegalArgumentException(UNAUTHORIZED_USER_MESSAGE);
+        }
+
+        List<Plamon> plamonList = plamonRepo.findAllByUser(user);
+        List<Pladex> notMyPlamonList = pladexRepo.findAllByUserWithNotMine(user);
+
+        return new ListAllPlamonResponse(plamonList, notMyPlamonList);
+    }
+
+    public PlamonRank getPlamonRank() {
+        int randomValue = random.nextInt(100) + 1;
+        PlamonRank plamonRank = null;
+
+        if (randomValue <= rankUtil.getProbabilityOfRank(PlamonRank.N)) {
+            plamonRank = PlamonRank.N;
+        } else if (randomValue <= rankUtil.getProbabilityOfRank(PlamonRank.R)) {
+            plamonRank = PlamonRank.R;
+        } else if (randomValue <= rankUtil.getProbabilityOfRank(PlamonRank.SR)) {
+            plamonRank = PlamonRank.SR;
+        } else if (randomValue <= rankUtil.getProbabilityOfRank(PlamonRank.SSR)) {
+            plamonRank = PlamonRank.SSR;
+        }
+        return plamonRank;
+    }
+
+    public Pladex selectOnePlamon(List<Pladex> pladexList) {
+        if (pladexList.isEmpty()) {
+            return null;
+        }
+
+        int randomValue = random.nextInt(pladexList.size());
+        return pladexList.get(randomValue);
+    }
+
+    /**
+     * 확률에 따라 뽑을 플레몬 랭크 선정
+     * 만약 해당 랭크의 플레몬이 없다면 다른 랭크 선정
+     */
+    public List<Pladex> getRandomPlamonListByRank() {
+        int size = rankUtil.getNumberOfRanks();
+        EnumMap<PlamonRank, Boolean> checkList = new EnumMap<>(PlamonRank.class);
+        List<Pladex> pladexList = new ArrayList<>();
+
+        while (size != checkList.size()) {
+            PlamonRank plamonRank = getPlamonRank();
+
+            if (checkList.containsKey(plamonRank)) {
+                continue;
+            }
+
+            checkList.put(plamonRank, true);
+
+            pladexList = pladexRepo.findAllByRank(plamonRank);
+            if (pladexList.isEmpty()) {
+                continue;
+            }
+
+            break;
+        }
+
+        return pladexList;
+    }
+
+    @Override
+    @Transactional
+    /**
+     * 캐릭터 뽑기
+     * 유저를 인증한 뒤, 뽑기를 할 수 있는 골드가 있는지 확인한다
+     * 랭크 별 획득 확률에 따라 뽑을 캐릭터의 랭크를 먼저 정한다
+     * 해당 랭크에 속한 캐릭터 중 랜덤으로 한 캐릭터를 뽑아 저장한다
+     * */
+    public PlamonResponse buyNewPlamonWithGold(String oauthUid) throws IllegalArgumentException, IllegalStateException{
+        User user = findUserByOauthUid(oauthUid);
+
+        if (user == null) {
+            throw new IllegalArgumentException(UNAUTHORIZED_USER_MESSAGE);
+        }
+
+        if (!user.hasEnoughGold(rankUtil.getGatchaPrice())) {
+            throw new IllegalStateException("캐릭터를 구매할 골드가 부족합니다");
+        }
+
+        List<Pladex> pladexList = getRandomPlamonListByRank();
+        Pladex randomPlamon = selectOnePlamon(pladexList);
+
+        if (randomPlamon == null) {
+            throw new UnsupportedOperationException("얻을 수 있는 캐릭터가 없습니다");
+        }
+
+        Plamon plamon = plamonRepo.save(new Plamon(randomPlamon, user));
+        user.minusGold(rankUtil.getGatchaPrice());
+
+        return new PlamonResponse(plamon);
+    }
+
+    /**
+     * 자신의 대표 캐릭터는 판매할 수 없음
+     * 레벨 * 캐릭터의 등급만큼 달고나를 얻음
+     * */
+    @Override
+    @Transactional
+    public ListSellPlamonResponse sell(String oauthUid, Long plamonId) throws IllegalArgumentException, IllegalStateException {
+        User user = findUserByOauthUid(oauthUid);
+
+        if (user == null) {
+            throw new IllegalArgumentException(UNAUTHORIZED_USER_MESSAGE);
+        }
+
+        Plamon plamon = plamonRepo.findPlamonByUserAndId(user, plamonId);
+
+        if (plamon == null) {
+            throw new IllegalStateException("해당 캐릭터는 보유 중이 아닙니다");
+        }
+
+        if (plamon.isMain()) {
+            throw new IllegalStateException("대표 캐릭터는 삭제할 수 없습니다");
+        }
+
+        // 해당 플레몬의 등급만큼의 금액을 번다
+        PlamonRank rank = plamon.getPladex().getRank();
+        int sellingDalgona = rankUtil.getSalesPriceOfRankAndLevel(rank, plamon.getLevel());
+        user.earnDalgona(sellingDalgona);
+
+        plamonRepo.delete(plamon);        //해당 플레몬 제거
+        ListAllPlamonResponse allByUser = findAllByUser(oauthUid);
+
+        return new ListSellPlamonResponse(user.getDalgona(), allByUser.getMyPlamon(), allByUser.getNotMyPlamon());
+    }
+
+}

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonService.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonService.java
@@ -3,13 +3,10 @@ package com.aespa.nextplace.service;
 import com.aespa.nextplace.model.request.PlamonChangeMainRequest;
 import com.aespa.nextplace.model.request.PlamonLevelUpRequest;
 import com.aespa.nextplace.model.response.ListAllPlamonResponse;
-import com.aespa.nextplace.model.response.ListSellPlamonResponse;
 import com.aespa.nextplace.model.response.PlamonResponse;
 
 public interface PlamonService {
     ListAllPlamonResponse findAllByUser(String oauthUid);
-    PlamonResponse buyNewPlamonWithGold(String oauthUid);
-    ListSellPlamonResponse sell(String oauthUid, Long plamonId);
     PlamonResponse levelUpWithDalgona(String oauthUid, PlamonLevelUpRequest request);
     PlamonResponse getMyMainPlamon(String oauthUid);
     PlamonResponse changeMainPlamon(String oauthUid, PlamonChangeMainRequest request);

--- a/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
+++ b/backend/src/main/java/com/aespa/nextplace/service/PlamonServiceImpl.java
@@ -1,6 +1,9 @@
 package com.aespa.nextplace.service;
 
-import com.aespa.nextplace.model.entity.*;
+import com.aespa.nextplace.model.entity.Experience;
+import com.aespa.nextplace.model.entity.Pladex;
+import com.aespa.nextplace.model.entity.Plamon;
+import com.aespa.nextplace.model.entity.User;
 import com.aespa.nextplace.model.repository.ExperienceRepository;
 import com.aespa.nextplace.model.repository.PladexRepository;
 import com.aespa.nextplace.model.repository.PlamonRepository;
@@ -8,17 +11,12 @@ import com.aespa.nextplace.model.repository.UserRepository;
 import com.aespa.nextplace.model.request.PlamonChangeMainRequest;
 import com.aespa.nextplace.model.request.PlamonLevelUpRequest;
 import com.aespa.nextplace.model.response.ListAllPlamonResponse;
-import com.aespa.nextplace.model.response.ListSellPlamonResponse;
 import com.aespa.nextplace.model.response.PlamonResponse;
 import com.aespa.nextplace.util.LevelUtil;
-import com.aespa.nextplace.util.PlamonRankUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.EnumMap;
 import java.util.List;
-import java.util.Random;
 
 @Service
 @Transactional(readOnly = true)
@@ -27,9 +25,7 @@ public class PlamonServiceImpl implements PlamonService {
     private final PladexRepository pladexRepo;
     private final UserRepository userRepo;
     private final ExperienceRepository expRepo;
-    private final PlamonRankUtil rankUtil;
     private final LevelUtil levelUtil;
-    private final Random random;
     private static final String UNAUTHORIZED_USER_MESSAGE = "존재하지 않는 유저입니다";
 
     public PlamonServiceImpl(PlamonRepository plamonRepo, PladexRepository pladexRepo, UserRepository userRepo, ExperienceRepository expRepo) {
@@ -37,9 +33,7 @@ public class PlamonServiceImpl implements PlamonService {
         this.pladexRepo = pladexRepo;
         this.userRepo = userRepo;
         this.expRepo = expRepo;
-        this.rankUtil = PlamonRankUtil.getInstance();
         this.levelUtil = LevelUtil.getInstance();
-        this.random = new Random();
     }
 
     public User findUserByOauthUid(String oauthUid){
@@ -58,126 +52,6 @@ public class PlamonServiceImpl implements PlamonService {
         List<Pladex> notMyPlamonList = pladexRepo.findAllByUserWithNotMine(user);
 
         return new ListAllPlamonResponse(plamonList, notMyPlamonList);
-    }
-
-    public PlamonRank getPlamonRank() {
-        int randomValue = random.nextInt(100) + 1;
-        PlamonRank plamonRank = null;
-
-        if (randomValue <= rankUtil.getProbabilityOfRank(PlamonRank.N)) {
-            plamonRank = PlamonRank.N;
-        } else if (randomValue <= rankUtil.getProbabilityOfRank(PlamonRank.R)) {
-            plamonRank = PlamonRank.R;
-        } else if (randomValue <= rankUtil.getProbabilityOfRank(PlamonRank.SR)) {
-            plamonRank = PlamonRank.SR;
-        } else if (randomValue <= rankUtil.getProbabilityOfRank(PlamonRank.SSR)) {
-            plamonRank = PlamonRank.SSR;
-        }
-        return plamonRank;
-    }
-
-    public Pladex selectOnePlamon(List<Pladex> pladexList) {
-        if (pladexList.isEmpty()) {
-            return null;
-        }
-
-        int randomValue = random.nextInt(pladexList.size());
-        return pladexList.get(randomValue);
-    }
-
-    /**
-     * 확률에 따라 뽑을 플레몬 랭크 선정
-     * 만약 해당 랭크의 플레몬이 없다면 다른 랭크 선정
-     */
-    public List<Pladex> getRandomPlamonListByRank() {
-        int size = rankUtil.getNumberOfRanks();
-        EnumMap<PlamonRank, Boolean> checkList = new EnumMap<>(PlamonRank.class);
-        List<Pladex> pladexList = new ArrayList<>();
-
-        while (size != checkList.size()) {
-            PlamonRank plamonRank = getPlamonRank();
-
-            if (checkList.containsKey(plamonRank)) {
-                continue;
-            }
-
-            checkList.put(plamonRank, true);
-
-            pladexList = pladexRepo.findAllByRank(plamonRank);
-            if (pladexList.isEmpty()) {
-                continue;
-            }
-
-            break;
-        }
-
-        return pladexList;
-    }
-
-    @Override
-    @Transactional
-    /**
-     * 캐릭터 뽑기
-     * 유저를 인증한 뒤, 뽑기를 할 수 있는 골드가 있는지 확인한다
-     * 랭크 별 획득 확률에 따라 뽑을 캐릭터의 랭크를 먼저 정한다
-     * 해당 랭크에 속한 캐릭터 중 랜덤으로 한 캐릭터를 뽑아 저장한다
-     * */
-    public PlamonResponse buyNewPlamonWithGold(String oauthUid) throws IllegalArgumentException, IllegalStateException{
-        User user = findUserByOauthUid(oauthUid);
-
-        if (user == null) {
-            throw new IllegalArgumentException(UNAUTHORIZED_USER_MESSAGE);
-        }
-
-        if (!user.hasEnoughGold(rankUtil.getGatchaPrice())) {
-            throw new IllegalStateException("캐릭터를 구매할 골드가 부족합니다");
-        }
-
-        List<Pladex> pladexList = getRandomPlamonListByRank();
-        Pladex randomPlamon = selectOnePlamon(pladexList);
-
-        if (randomPlamon == null) {
-            throw new UnsupportedOperationException("얻을 수 있는 캐릭터가 없습니다");
-        }
-
-        Plamon plamon = plamonRepo.save(new Plamon(randomPlamon, user));
-        user.minusGold(rankUtil.getGatchaPrice());
-
-        return new PlamonResponse(plamon);
-    }
-
-    /**
-     * 자신의 대표 캐릭터는 판매할 수 없음
-     * 레벨 * 캐릭터의 등급만큼 달고나를 얻음
-     * */
-    @Override
-    @Transactional
-    public ListSellPlamonResponse sell(String oauthUid, Long plamonId) throws IllegalArgumentException, IllegalStateException {
-        User user = findUserByOauthUid(oauthUid);
-
-        if (user == null) {
-            throw new IllegalArgumentException(UNAUTHORIZED_USER_MESSAGE);
-        }
-
-        Plamon plamon = plamonRepo.findPlamonByUserAndId(user, plamonId);
-
-        if (plamon == null) {
-            throw new IllegalStateException("해당 캐릭터는 보유 중이 아닙니다");
-        }
-
-        if (plamon.isMain()) {
-            throw new IllegalStateException("대표 캐릭터는 삭제할 수 없습니다");
-        }
-
-        // 해당 플레몬의 등급만큼의 금액을 번다
-        PlamonRank rank = plamon.getPladex().getRank();
-        int sellingDalgona = rankUtil.getSalesPriceOfRankAndLevel(rank, plamon.getLevel());
-        user.earnDalgona(sellingDalgona);
-
-        plamonRepo.delete(plamon);        //해당 플레몬 제거
-        ListAllPlamonResponse allByUser = findAllByUser(oauthUid);
-
-        return new ListSellPlamonResponse(user.getDalgona(), allByUser.getMyPlamon(), allByUser.getNotMyPlamon());
     }
 
     /**

--- a/backend/src/test/java/com/aespa/nextplace/plamon/PlamonDealServiceTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/plamon/PlamonDealServiceTest.java
@@ -1,0 +1,317 @@
+package com.aespa.nextplace.plamon;
+
+import com.aespa.nextplace.model.entity.*;
+import com.aespa.nextplace.model.repository.PladexRepository;
+import com.aespa.nextplace.model.repository.PlamonRepository;
+import com.aespa.nextplace.model.repository.UserRepository;
+import com.aespa.nextplace.model.response.ListSellPlamonResponse;
+import com.aespa.nextplace.model.response.PlamonResponse;
+import com.aespa.nextplace.service.PlamonDealServiceImpl;
+import com.aespa.nextplace.util.PlamonRankUtil;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+class PlamonDealServiceTest {
+
+    @InjectMocks
+    PlamonDealServiceImpl plamonDealService;
+
+    @Mock
+    PlamonRepository plamonRepo;
+
+    @Mock
+    UserRepository userRepo;
+
+    @Mock
+    PladexRepository pladexRepo;
+
+    private Pladex createPladexOfIdAndRank(long id, PlamonRank rank) {
+        return Pladex.builder()
+                .pladex(new Pladex("test", "test info", rank))
+                .id(id)
+                .build();
+    }
+
+    private Plamon createPlamon(long id, int level, int exp, boolean main, PlamonRank rank) {
+        return Plamon.builder()
+                .id(id)
+                .level(level)
+                .exp(exp)
+                .nickname("랩실노예")
+                .isMain(main)
+                .pladex(createPladexOfIdAndRank(1L, rank))
+                .user(createUser("G-12345", 1000, 10))
+                .build();
+    }
+
+    private User createUser(String uid, int gold, int dalgona) {
+        return User.builder()
+                .id(1L)
+                .user(new User(uid, "냉정한 고추참치"))
+                .role(UserRole.USER)
+                .gold(gold)
+                .dalgona(dalgona)
+                .avatar(null)
+                .build();
+    }
+
+    @DisplayName("N 등급을 랜덤으로 뽑을 수 있는지 검증한다")
+    @Test
+    void N등급뽑기() throws Exception {
+        //given
+        List<Pladex> normalPlamonList = List.of(
+                createPladexOfIdAndRank(1L, PlamonRank.N),
+                createPladexOfIdAndRank(2L, PlamonRank.N),
+                createPladexOfIdAndRank(3L, PlamonRank.N)
+        );
+        given(pladexRepo.findAllByRank(any(PlamonRank.class)))
+                .willReturn(normalPlamonList);
+
+        //when
+        List<Pladex> pladexList = plamonDealService.getRandomPlamonListByRank();
+
+        //then
+        assertThat(pladexList.size())
+                .isEqualTo(normalPlamonList.size());
+        assertThat(pladexList)
+                .extracting("id", "rank")
+                .containsExactly(
+                        tuple(1L, PlamonRank.N),
+                        tuple(2L, PlamonRank.N),
+                        tuple(3L, PlamonRank.N)
+                );
+        verify(pladexRepo).findAllByRank(any(PlamonRank.class));
+    }
+
+    @DisplayName("플레몬 리스트 중 랜덤으로 뽑는다")
+    @Test
+    void 여러개중랜덤뽑기() throws Exception {
+        //given
+        List<Pladex> normalPlamonList = List.of(
+                createPladexOfIdAndRank(1L, PlamonRank.N),
+                createPladexOfIdAndRank(2L, PlamonRank.N),
+                createPladexOfIdAndRank(3L, PlamonRank.N)
+        );
+
+        //when
+        Pladex pladex = plamonDealService.selectOnePlamon(normalPlamonList);
+
+        //then
+        assertThat(pladex)
+                .isNotNull();
+        assertThat(pladex.getRank())
+                .isEqualTo(PlamonRank.N);
+    }
+
+    @DisplayName("아무것도 없는데 뽑을 시 null")
+    @Test
+    void 없는데랜덤뽑기() throws Exception {
+        //given
+        List<Pladex> pladexList = new ArrayList<>();
+
+        //when
+        Pladex pladex = plamonDealService.selectOnePlamon(pladexList);
+
+        //then
+        assertThat(pladex)
+                .isNull();
+    }
+
+    @DisplayName("각각의 등급을 랜덤으로 뽑을 수 있는지 검증한다")
+    @Test
+    @Disabled
+    void 각각의등급뽑기() throws Exception {
+        //given
+        int count;
+
+        //when and then
+        for (var plamonRank : PlamonRank.values()) {
+            count = 0;
+
+            while (plamonDealService.getPlamonRank() != plamonRank) {
+                count++;
+            }
+
+            assertThat(count)
+                    .isGreaterThan(-1);
+        }
+    }
+
+    @DisplayName("골드를 사용해서 새로운 플레몬을 획득한다")
+    @Test
+    void 플레몬뽑기() throws IllegalArgumentException {
+        //given
+        User user = createUser("G-12345", 1000, 0);
+        List<Pladex> pladexList = List.of(
+                createPladexOfIdAndRank(1L, PlamonRank.N),
+                createPladexOfIdAndRank(2L, PlamonRank.N),
+                createPladexOfIdAndRank(3L, PlamonRank.N)
+        );
+        Pladex selectedPlamon = createPladexOfIdAndRank(1L, PlamonRank.SR);
+        Plamon plamon = new Plamon(selectedPlamon, user);
+
+        given(userRepo.findByOauthUid("G-12345"))
+                .willReturn(user);
+        given(pladexRepo.findAllByRank(any(PlamonRank.class)))
+                .willReturn(pladexList);
+        given(plamonRepo.save(any(Plamon.class)))
+                .willReturn(plamon);
+
+        //when
+        PlamonResponse plamonResponseDto = null;
+        plamonResponseDto = plamonDealService.buyNewPlamonWithGold(user.getOauthUid());
+
+
+        //then
+        assertThat(plamonResponseDto)
+                .isNotNull();
+        assertThat(plamonResponseDto.getId())
+                .isEqualTo(plamon.getId());
+        assertThat(plamonResponseDto.getPladex().getRank())
+                .isEqualTo(PlamonRank.SR);
+        assertThat(plamonResponseDto.getNickname())
+                .isEqualTo("test");
+        assertThat(user.getGold())
+                .isEqualTo(900);
+    }
+
+    @DisplayName("골드가 부족하면 캐릭터 구매 불가능")
+    @Test
+    void 플레몬뽑기골드부족() throws IllegalArgumentException {
+        //given
+        User user = createUser("G-12345", 50, 0);
+        given(userRepo.findByOauthUid("G-12345"))
+                .willReturn(user);
+
+        //when
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> plamonDealService.buyNewPlamonWithGold(user.getOauthUid()));
+
+
+        //then
+        assertThat(exception.getMessage())
+                .isEqualTo("캐릭터를 구매할 골드가 부족합니다");
+    }
+
+    @DisplayName("존재하지 않는 유저는 뽑기 불가")
+    @Test
+    void 캐릭터인증() throws Exception {
+        //given
+        User user = createUser("B-12345", 0, 0);
+        given(userRepo.findByOauthUid("B-12345"))
+                .willReturn(null);
+
+        //when
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> plamonDealService.buyNewPlamonWithGold(user.getOauthUid()));
+
+        //then
+        assertThat(exception.getMessage())
+                .isEqualTo("존재하지 않는 유저입니다");
+    }
+
+    @DisplayName("내가 가지고 있는 캐릭터를 판매한다")
+    @Test
+    void 캐릭터팔기() throws Exception {
+        //given
+        User user = createUser("G-12345", 1000, 0);
+        int preDalgona = user.getDalgona();
+        List<Plamon> afterPlamons = List.of(
+                createPlamon(1L, 1, 0, false, PlamonRank.SR),
+                createPlamon(3L, 1, 0, false, PlamonRank.SR)
+        );
+        Plamon sellingPlamon = createPlamon(2L, 1, 0, false, PlamonRank.SR);
+        given(userRepo.findByOauthUid("G-12345"))
+                .willReturn(user);
+        given(plamonRepo.findPlamonByUserAndId(user, 2L))
+                .willReturn(sellingPlamon);
+        given(plamonRepo.findAllByUser(user))
+                .willReturn(afterPlamons);
+        given(pladexRepo.findAllByUserWithNotMine(user))
+                .willReturn(List.of(sellingPlamon.getPladex()));
+
+        //when
+        ListSellPlamonResponse allPlamonResponse = plamonDealService.sell(user.getOauthUid(), sellingPlamon.getId());
+
+        //then
+        verify(userRepo, times(2)).findByOauthUid(user.getOauthUid());
+        verify(plamonRepo).findAllByUser(user);
+        verify(plamonRepo).delete(sellingPlamon);
+        assertThat(allPlamonResponse.getDalgona())
+                .isEqualTo(preDalgona
+                        + PlamonRankUtil.getInstance().getSalesPriceOfRankAndLevel(PlamonRank.SR, 1));
+        assertThat(allPlamonResponse.getMyPlamon())
+                .extracting("id", "level")
+                .containsExactly(
+                        tuple(1L, 1),
+                        tuple(3L, 1)
+                );
+        assertThat(allPlamonResponse.getNotMyPlamon().getPladexList())
+                .extracting("id", "rank")
+                .containsExactly(
+                        tuple(1L, PlamonRank.SR)
+                );
+        assertThat(user.getDalgona())
+                .isEqualTo(5);
+    }
+
+    @DisplayName("소유중이 아닌 캐릭터는 판매할 수 없다")
+    @Test
+    void 미소유캐릭터팔기() throws Exception {
+        //given
+        User user = createUser("G-12345", 1000, 0);
+        given(userRepo.findByOauthUid("G-12345"))
+                .willReturn(user);
+        given(plamonRepo.findPlamonByUserAndId(user, 2L))
+                .willReturn(null);
+
+        //when
+        IllegalStateException exception =
+                assertThrows(IllegalStateException.class,
+                        () -> plamonDealService.sell(user.getOauthUid(), 2L));
+
+        //then
+        assertThat(exception.getMessage())
+                .isEqualTo("해당 캐릭터는 보유 중이 아닙니다");
+    }
+
+    @DisplayName("대표 캐릭터는 판매할 수 없다")
+    @Test
+    void 대표캐릭터팔기() throws Exception {
+        //given
+        User user = createUser("G-12345", 1000, 0);
+        Plamon sellingPlamon = createPlamon(2L, 1, 0, true, PlamonRank.N);
+        given(userRepo.findByOauthUid("G-12345"))
+                .willReturn(user);
+        given(plamonRepo.findPlamonByUserAndId(user, 2L))
+                .willReturn(sellingPlamon);
+
+        //when
+        IllegalStateException exception =
+                assertThrows(IllegalStateException.class,
+                        () -> plamonDealService.sell(user.getOauthUid(), sellingPlamon.getId()));
+
+
+        //then
+        assertThat(exception.getMessage())
+                .isEqualTo("대표 캐릭터는 삭제할 수 없습니다");
+    }
+
+}

--- a/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/plamon/PlamonServiceTest.java
@@ -8,12 +8,9 @@ import com.aespa.nextplace.model.repository.UserRepository;
 import com.aespa.nextplace.model.request.PlamonChangeMainRequest;
 import com.aespa.nextplace.model.request.PlamonLevelUpRequest;
 import com.aespa.nextplace.model.response.ListAllPlamonResponse;
-import com.aespa.nextplace.model.response.ListSellPlamonResponse;
 import com.aespa.nextplace.model.response.PladexResponse;
 import com.aespa.nextplace.model.response.PlamonResponse;
 import com.aespa.nextplace.service.PlamonServiceImpl;
-import com.aespa.nextplace.util.PlamonRankUtil;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,15 +19,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -136,246 +130,6 @@ class PlamonServiceTest {
                 );
         verify(pladexRepo).findAllByUserWithNotMine(user);
         verify(plamonRepo).findAllByUser(user);
-    }
-
-    @DisplayName("N 등급을 랜덤으로 뽑을 수 있는지 검증한다")
-    @Test
-    void N등급뽑기() throws Exception {
-        //given
-        List<Pladex> normalPlamonList = List.of(
-                createPladexOfIdAndRank(1L, PlamonRank.N),
-                createPladexOfIdAndRank(2L, PlamonRank.N),
-                createPladexOfIdAndRank(3L, PlamonRank.N)
-        );
-        given(pladexRepo.findAllByRank(any(PlamonRank.class)))
-                .willReturn(normalPlamonList);
-
-        //when
-        List<Pladex> pladexList = plamonService.getRandomPlamonListByRank();
-
-        //then
-        assertThat(pladexList.size())
-                .isEqualTo(normalPlamonList.size());
-        assertThat(pladexList)
-                .extracting("id", "rank")
-                .containsExactly(
-                        tuple(1L, PlamonRank.N),
-                        tuple(2L, PlamonRank.N),
-                        tuple(3L, PlamonRank.N)
-                );
-        verify(pladexRepo).findAllByRank(any(PlamonRank.class));
-    }
-
-    @DisplayName("플레몬 리스트 중 랜덤으로 뽑는다")
-    @Test
-    void 여러개중랜덤뽑기() throws Exception {
-        //given
-        List<Pladex> normalPlamonList = List.of(
-                createPladexOfIdAndRank(1L, PlamonRank.N),
-                createPladexOfIdAndRank(2L, PlamonRank.N),
-                createPladexOfIdAndRank(3L, PlamonRank.N)
-        );
-
-        //when
-        Pladex pladex = plamonService.selectOnePlamon(normalPlamonList);
-
-        //then
-        assertThat(pladex)
-                .isNotNull();
-        assertThat(pladex.getRank())
-                .isEqualTo(PlamonRank.N);
-    }
-
-    @DisplayName("아무것도 없는데 뽑을 시 null")
-    @Test
-    void 없는데랜덤뽑기() throws Exception {
-        //given
-        List<Pladex> pladexList = new ArrayList<>();
-
-        //when
-        Pladex pladex = plamonService.selectOnePlamon(pladexList);
-
-        //then
-        assertThat(pladex)
-                .isNull();
-    }
-
-    @DisplayName("각각의 등급을 랜덤으로 뽑을 수 있는지 검증한다")
-    @Test
-    @Disabled
-    void 각각의등급뽑기() throws Exception {
-        //given
-        int count;
-
-        //when and then
-        for (var plamonRank : PlamonRank.values()) {
-            count = 0;
-
-            while (plamonService.getPlamonRank() != plamonRank) {
-                count++;
-            }
-
-            assertThat(count)
-                    .isGreaterThan(-1);
-        }
-    }
-
-    @DisplayName("골드를 사용해서 새로운 플레몬을 획득한다")
-    @Test
-    void 플레몬뽑기() throws IllegalArgumentException {
-        //given
-        User user = createUser("G-12345", 1000, 0);
-        List<Pladex> pladexList = List.of(
-                createPladexOfIdAndRank(1L, PlamonRank.N),
-                createPladexOfIdAndRank(2L, PlamonRank.N),
-                createPladexOfIdAndRank(3L, PlamonRank.N)
-        );
-        Pladex selectedPlamon = createPladexOfIdAndRank(1L, PlamonRank.SR);
-        Plamon plamon = new Plamon(selectedPlamon, user);
-
-        given(userRepo.findByOauthUid("G-12345"))
-                .willReturn(user);
-        given(pladexRepo.findAllByRank(any(PlamonRank.class)))
-                .willReturn(pladexList);
-        given(plamonRepo.save(any(Plamon.class)))
-                .willReturn(plamon);
-
-        //when
-        PlamonResponse plamonResponseDto = null;
-        plamonResponseDto = plamonService.buyNewPlamonWithGold(user.getOauthUid());
-
-
-        //then
-        assertThat(plamonResponseDto)
-                .isNotNull();
-        assertThat(plamonResponseDto.getId())
-                .isEqualTo(plamon.getId());
-        assertThat(plamonResponseDto.getPladex().getRank())
-                .isEqualTo(PlamonRank.SR);
-        assertThat(plamonResponseDto.getNickname())
-                .isEqualTo("test");
-        assertThat(user.getGold())
-                .isEqualTo(900);
-    }
-
-    @DisplayName("골드가 부족하면 캐릭터 구매 불가능")
-    @Test
-    void 플레몬뽑기골드부족() throws IllegalArgumentException {
-        //given
-        User user = createUser("G-12345", 50, 0);
-        given(userRepo.findByOauthUid("G-12345"))
-                .willReturn(user);
-
-        //when
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> plamonService.buyNewPlamonWithGold(user.getOauthUid()));
-
-
-        //then
-        assertThat(exception.getMessage())
-                .isEqualTo("캐릭터를 구매할 골드가 부족합니다");
-    }
-
-    @DisplayName("존재하지 않는 유저는 뽑기 불가")
-    @Test
-    void 캐릭터인증() throws Exception {
-        //given
-        User user = createUser("B-12345", 0, 0);
-        given(userRepo.findByOauthUid("B-12345"))
-                .willReturn(null);
-
-        //when
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> plamonService.buyNewPlamonWithGold(user.getOauthUid()));
-
-        //then
-        assertThat(exception.getMessage())
-                .isEqualTo("존재하지 않는 유저입니다");
-    }
-
-    @DisplayName("내가 가지고 있는 캐릭터를 판매한다")
-    @Test
-    void 캐릭터팔기() throws Exception {
-        //given
-        User user = createUser("G-12345", 1000, 0);
-        int preDalgona = user.getDalgona();
-        List<Plamon> afterPlamons = List.of(
-                createPlamon(1L, 1, 0, false, PlamonRank.SR),
-                createPlamon(3L, 1, 0, false, PlamonRank.SR)
-        );
-        Plamon sellingPlamon = createPlamon(2L, 1, 0, false, PlamonRank.SR);
-        given(userRepo.findByOauthUid("G-12345"))
-                .willReturn(user);
-        given(plamonRepo.findPlamonByUserAndId(user, 2L))
-                .willReturn(sellingPlamon);
-        given(plamonRepo.findAllByUser(user))
-                .willReturn(afterPlamons);
-        given(pladexRepo.findAllByUserWithNotMine(user))
-                .willReturn(List.of(sellingPlamon.getPladex()));
-
-        //when
-        ListSellPlamonResponse allPlamonResponse = plamonService.sell(user.getOauthUid(), sellingPlamon.getId());
-
-        //then
-        verify(userRepo, times(2)).findByOauthUid(user.getOauthUid());
-        verify(plamonRepo).findAllByUser(user);
-        verify(plamonRepo).delete(sellingPlamon);
-        assertThat(allPlamonResponse.getDalgona())
-                .isEqualTo(preDalgona
-                        + PlamonRankUtil.getInstance().getSalesPriceOfRankAndLevel(PlamonRank.SR, 1));
-        assertThat(allPlamonResponse.getMyPlamon())
-                .extracting("id", "level")
-                .containsExactly(
-                        tuple(1L, 1),
-                        tuple(3L, 1)
-                );
-        assertThat(allPlamonResponse.getNotMyPlamon().getPladexList())
-                .extracting("id", "rank")
-                .containsExactly(
-                        tuple(1L, PlamonRank.SR)
-                );
-        assertThat(user.getDalgona())
-                .isEqualTo(5);
-    }
-
-    @DisplayName("소유중이 아닌 캐릭터는 판매할 수 없다")
-    @Test
-    void 미소유캐릭터팔기() throws Exception {
-        //given
-        User user = createUser("G-12345", 1000, 0);
-        given(userRepo.findByOauthUid("G-12345"))
-                .willReturn(user);
-        given(plamonRepo.findPlamonByUserAndId(user, 2L))
-                .willReturn(null);
-
-        //when
-        IllegalStateException exception =
-                assertThrows(IllegalStateException.class,
-                        () -> plamonService.sell(user.getOauthUid(), 2L));
-
-        //then
-        assertThat(exception.getMessage())
-                .isEqualTo("해당 캐릭터는 보유 중이 아닙니다");
-    }
-
-    @DisplayName("대표 캐릭터는 판매할 수 없다")
-    @Test
-    void 대표캐릭터팔기() throws Exception {
-        //given
-        User user = createUser("G-12345", 1000, 0);
-        Plamon sellingPlamon = createPlamon(2L, 1, 0, true, PlamonRank.N);
-        given(userRepo.findByOauthUid("G-12345"))
-                .willReturn(user);
-        given(plamonRepo.findPlamonByUserAndId(user, 2L))
-                .willReturn(sellingPlamon);
-
-        //when
-        IllegalStateException exception =
-                assertThrows(IllegalStateException.class,
-                        () -> plamonService.sell(user.getOauthUid(), sellingPlamon.getId()));
-
-
-        //then
-        assertThat(exception.getMessage())
-                .isEqualTo("대표 캐릭터는 삭제할 수 없습니다");
     }
 
     @DisplayName("캐릭터를 1레벨 업한다")


### PR DESCRIPTION
## Motivation 🤔

- 기존 PlamonService 클래스가 너무 많은 책임과 코드를 가지고 있기 때문에 이를 두 클래스로 분리하려 했습니다
  - PlamonService : 캐릭터 조회/레벨 업/대표 캐릭터 설정 등의 비즈니스 로직 구현
  - PlamonDealService : 캐릭터 뽑기/판매 비즈니스 로직을 구현
- 하나의 클래스에 몰려있던 불필요한 책임을 나누고자 했습니다

<br>

## Key Changes 🔑

- Service 클래스만 수정하기 때문에 이를 참조중인 Controller는 하나의 추가 필드를 가질 뿐 영향이 가지 않도록 구현했습니다
- LevelUtil과 ExperienceRepository은 PlamonService에서만, PlamonRandomUtil은 PlamonDealService에서만 참조하도록 분리했습니다


<br>

## To Reviewers 🙏

- Test 클래스와 Service 클래스를 분리하느라 코드 변화 양이 많아졌습니다. 
- 컨트롤러에서 변화는 없고 Service 테스트는 모두 통과하는 상태라서 기존 기능에는 문제가 없을 것으로 예상됩니다.
