### PR TITLE
Close #136 - Hotfix/gatcha by rank

### DIFF
--- a/backend/src/main/java/com/aespa/nextplace/model/repository/PladexRepository.java
+++ b/backend/src/main/java/com/aespa/nextplace/model/repository/PladexRepository.java
@@ -15,8 +15,8 @@ public interface PladexRepository extends JpaRepository<Pladex, Long> {
 
     Pladex findByName(String name);
 
-    @Query("select d from Pladex d where d.name <> '기본캐릭터'")
-    List<Pladex> findAllByRank(PlamonRank rank);
+    @Query("select d from Pladex d where d.rank = :rank and d.name <> '기본캐릭터'")
+    List<Pladex> findAllByRank(@Param("rank") PlamonRank rank);
 
     @Query("select distinct d from Pladex d " +
             "left outer join Plamon m on m.pladex = d " +

--- a/backend/src/test/java/com/aespa/nextplace/pladex/PladexRepositoryTest.java
+++ b/backend/src/test/java/com/aespa/nextplace/pladex/PladexRepositoryTest.java
@@ -1,10 +1,8 @@
 package com.aespa.nextplace.pladex;
 
 import com.aespa.nextplace.model.entity.Pladex;
-import com.aespa.nextplace.model.entity.User;
+import com.aespa.nextplace.model.entity.PlamonRank;
 import com.aespa.nextplace.model.repository.PladexRepository;
-import com.aespa.nextplace.model.repository.UserRepository;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,27 +17,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 @DataJpaTest
-@Disabled
+//@Disabled
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class PladexRepositoryTest {
     @Autowired private PladexRepository pladexRepo;
-    @Autowired private UserRepository userRepo;
 
-
-    @DisplayName("내가 안 가진 캐릭터 조회")
+    @DisplayName("등급 별 캐릭터 조회")
     @Test
-    void 내가_안가진_캐릭터_조회() {
+    void 등급별_캐릭터_조회() {
         //given
-        User user = userRepo.findByOauthUid("G-12345");
+        PlamonRank rank = PlamonRank.N;
 
         //when
-        List<Pladex> notMine = pladexRepo.findAllByUserWithNotMine(user);
+        List<Pladex> pladexList = pladexRepo.findAllByRank(rank);
 
         //then
-        for (Pladex pladex: notMine) {
-            System.out.println(pladex.toString());
+        for (Pladex pladex: pladexList) {
+            assertThat(pladex.getRank())
+                    .isEqualTo(rank);
         }
-        assertThat(notMine.size())
-                .isEqualTo(2);
     }
 }


### PR DESCRIPTION
## Motivation 🤔

- 등급 별 캐릭터를 뽑는 `PladexRepository`의 `findAllByRank`메서드가 제대로 동작하지 않는 버그 존재
- `@DataJpaTest`를 사용한 Repository Test의 Ignore를 풀었다가 실패하는 케이스 발견

<br>

## Key Changes 🔑

- 기존 Spring Data JPA가 메서드명으로 쿼리를 만들어주었었는데, 기본캐릭터를 제외하는 JPQL을 잘못 추가해서 랭크별로 조회하지 않는 오류가 발생한 것 같습니다.

기존
```java
    List<Pladex> findAllByRank(@Param("rank") PlamonRank rank);
```

쿼리문을 추가하면서 rank별로 조회하는 where절을 추가하지 않음
```java
    @Query("select d from Pladex d where d.name <> '기본캐릭터'")
    List<Pladex> findAllByRank(PlamonRank rank);
```

수정한 쿼리문
```java
    @Query("select d from Pladex d where d.rank = :rank and d.name <> '기본캐릭터'")
    List<Pladex> findAllByRank(@Param("rank") PlamonRank rank);
```

<br>

## To Reviewers 🙏

- Service Layer에서 테스트하느라 Repository의 반환값은 Stubbing해주었기 때문에 쉬운 오류였지만 발견할 수 없었습니다
- 그래서 Layer 별로 단위 테스트를 별도로 진행하는 것이 중요하다는 걸 느꼈습니다 ..
