### PR TITLE
fix:[#140] 캐시 비밀번호 설정 추가

### DIFF
--- a/backend/src/main/java/com/aespa/nextplace/config/CacheConfig.java
+++ b/backend/src/main/java/com/aespa/nextplace/config/CacheConfig.java
@@ -1,6 +1,5 @@
 package com.aespa.nextplace.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,17 +12,13 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 public class CacheConfig {
-  
-  @Autowired
-  RedisConnectionFactory redisConnectionFactory;
-  
-  @Autowired
-  ObjectMapper objectMapper;
-  
-  @Autowired
-  RedisConnectionFactory connectionFactory;
+    
+  private final RedisConnectionFactory connectionFactory;
   
   
   @Bean

--- a/backend/src/main/java/com/aespa/nextplace/config/RedisConfig.java
+++ b/backend/src/main/java/com/aespa/nextplace/config/RedisConfig.java
@@ -1,6 +1,5 @@
 package com.aespa.nextplace.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,17 +12,21 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 public class RedisConfig {
   
   @Value("${spring.redis.port}")
-  public int port;
+  private int port;
   
   @Value("${spring.redis.host}")
-  public String host;
+  private String host;
   
-  @Autowired
-  public ObjectMapper objectMapper;
+  @Value("${spring.redis.password}")
+  private String password;
+
   
   @Bean
   public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
@@ -39,6 +42,7 @@ public class RedisConfig {
     RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
     redisStandaloneConfiguration.setHostName(host);
     redisStandaloneConfiguration.setPort(port);
+    redisStandaloneConfiguration.setPassword(password);    
     LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
     return connectionFactory;
   }


### PR DESCRIPTION
## Motivation 🤔
- RedisUtil에서 자동으로 생성된 RedisTemplate에서는 yml 에서 자동으로 비밀번호를 가져오길래 적용이 되는 줄 알았는데 @Cacheable에서는 달랐습니다.
- 그래서 비밀번호를 넣어주는 설정을 추가하였습니다.

<br>

## Key Changes 🔑
- RedisConfig에서 비밀번호 설정을 추가

<br>

## To Reviewers 🙏
- 로컬에서 테스트할 때는 Redis에 비밀번호가 없어서 확인 못 했던 이슈였습니다. 다음에는 로컬도 개발 환경과 최대한 똑같이 구성해야겠다고 느꼈습니다.
